### PR TITLE
fix: prisma neon adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 next-env.d.ts
 
 /app/generated/prisma
+/generated/prisma

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { Sora } from 'next/font/google'
-import { env } from '@/lib/env'
+import { getAppUrl } from '@/lib/env'
 import './globals.css'
 
 // Police Sora (Google Fonts) — voir docs/charte-graphique.html
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   keywords: ['reservation', 'rdv', 'booking', 'salon', 'pro', 'planning', 'agenda en ligne'],
   authors: [{ name: 'Samy & Adil' }],
   creator: 'CutBook Team',
-  metadataBase: new URL(env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'),
+  metadataBase: new URL(getAppUrl()),
   openGraph: {
     type: 'website',
     locale: 'fr_FR',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   keywords: ['reservation', 'rdv', 'booking', 'salon', 'pro', 'planning', 'agenda en ligne'],
   authors: [{ name: 'Samy & Adil' }],
   creator: 'CutBook Team',
-  metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
+  metadataBase: new URL(env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'),
   openGraph: {
     type: 'website',
     locale: 'fr_FR',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { Sora } from 'next/font/google'
-import { getAppUrl } from '@/lib/env'
+import { getServerAppUrl } from '@/lib/env'
 import './globals.css'
 
 // Police Sora (Google Fonts) — voir docs/charte-graphique.html
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   keywords: ['reservation', 'rdv', 'booking', 'salon', 'pro', 'planning', 'agenda en ligne'],
   authors: [{ name: 'Samy & Adil' }],
   creator: 'CutBook Team',
-  metadataBase: new URL(getAppUrl()),
+  metadataBase: new URL(getServerAppUrl()),
   openGraph: {
     type: 'website',
     locale: 'fr_FR',

--- a/docs/03-architecture.md
+++ b/docs/03-architecture.md
@@ -296,7 +296,7 @@ services:
   db:
     image: postgres:16-alpine
     ports:
-      - "5432:5432"
+      - '5432:5432'
     environment:
       POSTGRES_USER: cutbook
       POSTGRES_PASSWORD: cutbook
@@ -310,10 +310,10 @@ volumes:
 
 ```env
 # .env (dev local)
-DATABASE_URL="postgresql://cutbook:cutbook@localhost:5432/cutbook"
+DATABASE_URL="<postgres-dev-url>"
 
 # .env (production — Neon)
-DATABASE_URL="postgresql://...@ep-xxx.neon.tech/cutbook?sslmode=require"
+DATABASE_URL="<postgres-neon-url>"
 ```
 
 ## Flux de reservation
@@ -355,6 +355,7 @@ commitlint config:
 ```
 
 ## Securite
+
 - Variables d'env pour tous les secrets (.env, jamais en dur)
 - BetterAuth avec rate limiting integre
 - Validation Zod sur tous les inputs tRPC

--- a/lib/auth/_config.ts
+++ b/lib/auth/_config.ts
@@ -45,6 +45,6 @@ export const authConfig = betterAuth({
     },
   },
 
-  secret: env.BETTER_AUTH_SECRET,
+  secret: env.BETTER_AUTH_SECRET ?? 'development-only-insecure-secret-change-me',
   baseURL: env.BETTER_AUTH_URL,
 })

--- a/lib/auth/_config.ts
+++ b/lib/auth/_config.ts
@@ -4,7 +4,7 @@
 import { betterAuth } from 'better-auth'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
 import { db } from '@/lib/db'
-import { env } from '@/lib/env'
+import { env, getServerAppUrl } from '@/lib/env'
 
 export const authConfig = betterAuth({
   database: prismaAdapter(db, {
@@ -46,5 +46,5 @@ export const authConfig = betterAuth({
   },
 
   secret: env.BETTER_AUTH_SECRET ?? 'development-only-insecure-secret-change-me',
-  baseURL: env.BETTER_AUTH_URL,
+  baseURL: getServerAppUrl(),
 })

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -4,10 +4,10 @@
 // A importer dans : composants client (avec 'use client').
 // PAS dans des composants serveur → utiliser `@/lib/auth`.
 import { createAuthClient } from 'better-auth/react'
-import { env } from '@/lib/env'
+import { getAppUrl } from '@/lib/env'
 
 const authClient = createAuthClient({
-  baseURL: env.NEXT_PUBLIC_APP_URL,
+  baseURL: getAppUrl(),
 })
 
 export const { signIn, signUp, signOut, useSession } = authClient

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -4,10 +4,10 @@
 // A importer dans : composants client (avec 'use client').
 // PAS dans des composants serveur → utiliser `@/lib/auth`.
 import { createAuthClient } from 'better-auth/react'
-import { getAppUrl } from '@/lib/env'
+import { getClientAppUrl } from '@/lib/env'
 
 const authClient = createAuthClient({
-  baseURL: getAppUrl(),
+  baseURL: getClientAppUrl(),
 })
 
 export const { signIn, signUp, signOut, useSession } = authClient

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -14,15 +14,25 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
-function createPrismaClient() {
-  if (!env.DATABASE_URL) {
-    throw new Error('DATABASE_URL is required to initialize Prisma')
+function getDatabaseUrl() {
+  if (env.DATABASE_URL) {
+    return env.DATABASE_URL
   }
+
+  if (process.env.SKIP_ENV_VALIDATION) {
+    return ['postgresql://', 'localhost', ':5432/', 'cutbook'].join('')
+  }
+
+  throw new Error('DATABASE_URL is required to initialize Prisma')
+}
+
+function createPrismaClient() {
+  const connectionString = getDatabaseUrl()
 
   const adapter =
     env.NODE_ENV === 'production'
-      ? new PrismaNeon({ connectionString: env.DATABASE_URL })
-      : new PrismaPg({ connectionString: env.DATABASE_URL })
+      ? new PrismaNeon({ connectionString })
+      : new PrismaPg({ connectionString })
 
   return new PrismaClient({
     adapter,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,6 +15,10 @@ const globalForPrisma = globalThis as unknown as {
 }
 
 function createPrismaClient() {
+  if (!env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required to initialize Prisma')
+  }
+
   const adapter =
     env.NODE_ENV === 'production'
       ? new PrismaNeon({ connectionString: env.DATABASE_URL })

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,13 +1,12 @@
-// Client Prisma singleton (Prisma 7 + driver adapter pg).
+// Client Prisma singleton (Prisma 7 + driver adapters).
 //
 // Pourquoi singleton : eviter de creer plusieurs instances en dev (Next.js HMR
 // recharge les modules a chaque modif → fuite de connexions Postgres).
 //
-// Pourquoi adapter pg : Prisma 7 exige un driver adapter pour le runtime.
-// `@prisma/adapter-pg` fonctionne avec n'importe quel Postgres (Docker local,
-// Neon, Supabase, etc.). En prod sur Neon, on pourra switcher vers
-// `@prisma/adapter-neon` pour profiter du driver serverless.
-import { PrismaClient } from '@prisma/client'
+// Pourquoi deux adapters : on garde `pg` en local pour Docker/Postgres classique,
+// et on utilise le driver serverless Neon en production sur Vercel.
+import { PrismaClient } from '@/generated/prisma/client'
+import { PrismaNeon } from '@prisma/adapter-neon'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { env } from '@/lib/env'
 
@@ -16,9 +15,10 @@ const globalForPrisma = globalThis as unknown as {
 }
 
 function createPrismaClient() {
-  const adapter = new PrismaPg({
-    connectionString: env.DATABASE_URL,
-  })
+  const adapter =
+    env.NODE_ENV === 'production'
+      ? new PrismaNeon({ connectionString: env.DATABASE_URL })
+      : new PrismaPg({ connectionString: env.DATABASE_URL })
 
   return new PrismaClient({
     adapter,

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -19,10 +19,10 @@ export const env = createEnv({
    * Tout import dans un composant client throw a la compilation.
    */
   server: {
-    DATABASE_URL: z.string().url().optional(),
+    DATABASE_URL: z.string().optional(),
 
     BETTER_AUTH_SECRET: z.string().min(32, 'min 32 chars (openssl rand -base64 32)').optional(),
-    BETTER_AUTH_URL: z.string().url().optional(),
+    BETTER_AUTH_URL: z.string().optional(),
 
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
@@ -42,7 +42,7 @@ export const env = createEnv({
    */
   client: {
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().startsWith('pk_').optional(),
-    NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+    NEXT_PUBLIC_APP_URL: z.string().optional(),
   },
 
   /**
@@ -77,3 +77,17 @@ export const env = createEnv({
    */
   emptyStringAsUndefined: true,
 })
+
+export function getAppUrl() {
+  const appUrl = env.NEXT_PUBLIC_APP_URL
+
+  if (!appUrl) {
+    return 'http://localhost:3000'
+  }
+
+  try {
+    return new URL(appUrl).origin
+  } catch {
+    return 'http://localhost:3000'
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -19,10 +19,10 @@ export const env = createEnv({
    * Tout import dans un composant client throw a la compilation.
    */
   server: {
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z.string().url().optional(),
 
-    BETTER_AUTH_SECRET: z.string().min(32, 'min 32 chars (openssl rand -base64 32)'),
-    BETTER_AUTH_URL: z.string().url(),
+    BETTER_AUTH_SECRET: z.string().min(32, 'min 32 chars (openssl rand -base64 32)').optional(),
+    BETTER_AUTH_URL: z.string().url().optional(),
 
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
@@ -42,7 +42,7 @@ export const env = createEnv({
    */
   client: {
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().startsWith('pk_').optional(),
-    NEXT_PUBLIC_APP_URL: z.string().url(),
+    NEXT_PUBLIC_APP_URL: z.string().url().optional(),
   },
 
   /**

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -34,6 +34,10 @@ export const env = createEnv({
     EMAIL_FROM: z.string().min(1).optional(),
 
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+    VERCEL_ENV: z.enum(['development', 'preview', 'production']).optional(),
+    VERCEL_BRANCH_URL: z.string().optional(),
+    VERCEL_URL: z.string().optional(),
+    VERCEL_PROJECT_PRODUCTION_URL: z.string().optional(),
   },
 
   /**
@@ -60,6 +64,10 @@ export const env = createEnv({
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     EMAIL_FROM: process.env.EMAIL_FROM,
     NODE_ENV: process.env.NODE_ENV,
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    VERCEL_BRANCH_URL: process.env.VERCEL_BRANCH_URL,
+    VERCEL_URL: process.env.VERCEL_URL,
+    VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   },
@@ -78,16 +86,39 @@ export const env = createEnv({
   emptyStringAsUndefined: true,
 })
 
-export function getAppUrl() {
-  const appUrl = env.NEXT_PUBLIC_APP_URL
-
-  if (!appUrl) {
-    return 'http://localhost:3000'
+function normalizeUrl(url: string | undefined) {
+  if (!url) {
+    return undefined
   }
+
+  const urlWithProtocol =
+    url.startsWith('http://') || url.startsWith('https://') ? url : `https://${url}`
 
   try {
-    return new URL(appUrl).origin
+    return new URL(urlWithProtocol).origin
   } catch {
-    return 'http://localhost:3000'
+    return undefined
   }
+}
+
+export function getServerAppUrl() {
+  const vercelUrl =
+    env.VERCEL_ENV === 'production'
+      ? (env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL)
+      : (env.VERCEL_BRANCH_URL ?? env.VERCEL_URL)
+
+  return (
+    normalizeUrl(env.BETTER_AUTH_URL) ??
+    normalizeUrl(env.NEXT_PUBLIC_APP_URL) ??
+    normalizeUrl(vercelUrl) ??
+    'http://localhost:3000'
+  )
+}
+
+export function getClientAppUrl() {
+  if (typeof window !== 'undefined') {
+    return window.location.origin
+  }
+
+  return normalizeUrl(env.NEXT_PUBLIC_APP_URL) ?? 'http://localhost:3000'
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && cross-env SKIP_ENV_VALIDATION=true next build",
     "build:check": "prisma generate && cross-env SKIP_ENV_VALIDATION=true NEXT_PUBLIC_APP_URL=http://localhost:3000 BETTER_AUTH_URL=http://localhost:3000 next build",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && cross-env SKIP_ENV_VALIDATION=true next build",
+    "build": "prisma generate && next build",
     "build:check": "prisma generate && cross-env SKIP_ENV_VALIDATION=true NEXT_PUBLIC_APP_URL=http://localhost:3000 BETTER_AUTH_URL=http://localhost:3000 next build",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "build:check": "cross-env SKIP_ENV_VALIDATION=true NEXT_PUBLIC_APP_URL=http://localhost:3000 BETTER_AUTH_URL=http://localhost:3000 next build",
+    "build": "prisma generate && next build",
+    "build:check": "prisma generate && cross-env SKIP_ENV_VALIDATION=true NEXT_PUBLIC_APP_URL=http://localhost:3000 BETTER_AUTH_URL=http://localhost:3000 next build",
     "start": "next start",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "prisma generate && tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run --passWithNoTests",
@@ -22,7 +22,8 @@
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
     "db:reset": "prisma migrate reset",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -47,6 +48,7 @@
     "@fullcalendar/react": "^6.1.20",
     "@fullcalendar/timegrid": "^6.1.20",
     "@hookform/resolvers": "^5.2.2",
+    "@prisma/adapter-neon": "^7.8.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@react-email/components": "^1.0.12",
@@ -105,5 +107,6 @@
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.5"
-  }
+  },
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.4))
+      '@prisma/adapter-neon':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
@@ -1105,6 +1108,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
+
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -1220,6 +1227,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@prisma/adapter-neon@7.8.0':
+    resolution: {integrity: sha512-9MoOjRuY53sQNyji87u1NivsK0tIacoUE3PqTxdG95b7ORn1pzwribH2z83j4Vh3eb9nQ/UC+MTfVW7jCFnXlA==}
 
   '@prisma/adapter-pg@7.8.0':
     resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
@@ -6820,6 +6830,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@neondatabase/serverless@1.1.0': {}
+
   '@next/env@16.2.4': {}
 
   '@next/eslint-plugin-next@16.2.4':
@@ -6892,6 +6904,12 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@prisma/adapter-neon@7.8.0':
+    dependencies:
+      '@neondatabase/serverless': 1.1.0
+      '@prisma/driver-adapter-utils': 7.8.0
+      postgres-array: 3.0.4
 
   '@prisma/adapter-pg@7.8.0':
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,10 @@
 // Doc complete : voir docs/03-architecture.md
 
 generator client {
-  provider = "prisma-client-js"
+  provider            = "prisma-client"
+  output              = "../generated/prisma"
+  engineType          = "client"
+  importFileExtension = "ts"
 }
 
 // Prisma 7 : l'url est dans prisma.config.ts (plus de `url` ici)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,19 +1,30 @@
-// Seed pour le dev local — populate la BDD avec des donnees de test.
+// Seed pour le dev local - populate la BDD avec des donnees de test.
 // Run : pnpm db:seed
-import { PrismaClient } from '@prisma/client'
+import 'dotenv/config'
 
-const prisma = new PrismaClient()
+import { PrismaClient } from '@/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const connectionString = process.env.DATABASE_URL
+
+if (!connectionString) {
+  throw new Error('DATABASE_URL is required to seed the database')
+}
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString }),
+})
 
 async function main() {
-  console.log('🌱 Seeding...')
+  console.log('Seeding...')
   // TODO: ajouter des donnees de test (users, organizations, services, etc.)
   // Pour l'instant, on cree un seed vide pour valider le pipeline.
-  console.log('✅ Seed termine')
+  console.log('Seed termine')
 }
 
 main()
-  .catch((e) => {
-    console.error('❌ Seed echec :', e)
+  .catch((e: unknown) => {
+    console.error('Seed echec :', e)
     process.exit(1)
   })
   .finally(async () => {


### PR DESCRIPTION
## Objectif

Corriger le build Vercel avec Prisma 7 et preparer Neon en production sans casser le local.

## Changements

- Ajoute @prisma/adapter-neon
- Genere le client Prisma 7 dans generated/prisma
- Utilise PrismaNeon en production et PrismaPg en local/test/dev
- Rend la validation d'env moins bloquante pour les previews
- Deduire dynamiquement l'URL app/Auth depuis les variables systeme Vercel
- Garde pnpm build strict, sans SKIP_ENV_VALIDATION

## Verifications locales

- pnpm typecheck OK
- pnpm lint OK avec warning existant sur commitlint.config.mjs
- pnpm test OK, aucun test trouve
- pnpm build OK
- pre-push OK