### PR TITLE
feat: add auth flow

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { AuthShell } from '@/components/auth/auth-shell'
+import { ForgotPasswordForm } from '@/components/auth/forgot-password-form'
+
+export const metadata: Metadata = {
+  title: 'Mot de passe oublie',
+  description: 'Reinitialisez votre mot de passe CutBook.',
+}
+
+export default function ForgotPasswordPage() {
+  return (
+    <AuthShell
+      title="Mot de passe oublie ?"
+      description="Renseignez votre email pour recevoir un lien de reinitialisation."
+      brandTitle="Recuperez votre acces"
+      brandHighlight="en quelques minutes."
+      brandDescription="Les liens de reinitialisation sont emis par BetterAuth et expirent automatiquement."
+    >
+      <ForgotPasswordForm />
+    </AuthShell>
+  )
+}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { AuthShell } from '@/components/auth/auth-shell'
+import { LoginForm } from '@/components/auth/login-form'
+
+export const metadata: Metadata = {
+  title: 'Connexion - CutBook',
+  description: 'Connectez-vous a votre espace CutBook.',
+}
+
+export default function LoginPage() {
+  return (
+    <AuthShell
+      title="Bon retour"
+      description="Connectez-vous pour acceder a votre espace."
+      brandTitle="Vos clients reservent"
+      brandHighlight="meme quand vous dormez."
+      brandDescription="Reservation en ligne, paiement Stripe et fidelite automatique."
+    >
+      <LoginForm />
+    </AuthShell>
+  )
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next'
+import { AuthShell } from '@/components/auth/auth-shell'
+import { RegisterForm } from '@/components/auth/register-form'
+
+export const metadata: Metadata = {
+  title: 'Creer un compte - CutBook',
+  description: 'Creez votre espace CutBook et demarrez la reservation en ligne.',
+}
+
+export default function RegisterPage() {
+  return (
+    <AuthShell
+      title="Creer mon espace"
+      description="Gratuit. Aucune carte bancaire requise."
+      brandTitle="Rejoignez les professionnels"
+      brandHighlight="qui ont digitalise leur salon."
+      brandDescription="Ouvrez votre espace, configurez vos services et recevez vos premieres reservations."
+      brandStats={[
+        { value: '100%', label: 'gratuit au depart' },
+        { value: '24/7', label: 'reservations actives' },
+        { value: '0 EUR', label: 'sans carte bancaire' },
+      ]}
+    >
+      <RegisterForm />
+    </AuthShell>
+  )
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { AuthShell } from '@/components/auth/auth-shell'
+import { ResetPasswordForm } from '@/components/auth/reset-password-form'
+
+export const metadata: Metadata = {
+  title: 'Reinitialiser le mot de passe',
+  robots: { index: false },
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <AuthShell
+      title="Nouveau mot de passe"
+      description="Choisissez un mot de passe securise d'au moins 8 caracteres."
+      brandTitle="Securisez votre compte"
+      brandHighlight="avant de reprendre."
+      brandDescription="La reinitialisation utilise le token emis par BetterAuth dans le lien email."
+    >
+      <Suspense fallback={<div className="bg-muted h-32 animate-pulse rounded-md" />}>
+        <ResetPasswordForm />
+      </Suspense>
+    </AuthShell>
+  )
+}

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Mail } from 'lucide-react'
+import { AuthShell } from '@/components/auth/auth-shell'
+
+export const metadata: Metadata = {
+  title: 'Verification email',
+  description: 'Verifiez votre adresse email pour activer votre compte CutBook.',
+  robots: { index: false },
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <AuthShell
+      title="Verifiez votre email"
+      description="Activez votre compte depuis le lien envoye par email."
+      brandTitle="Votre espace est pret"
+      brandHighlight="il reste l'email."
+      brandDescription="La verification protege les comptes et limite les inscriptions abusives."
+    >
+      <div className="bg-card space-y-4 rounded-xl border p-8 text-center shadow-sm">
+        <div className="flex justify-center">
+          <div className="bg-primary/10 flex size-16 items-center justify-center rounded-full">
+            <Mail className="text-primary size-8" />
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">Verifie ton email</h2>
+          <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+            On t&apos;a envoye un lien de confirmation. Clique dessus pour activer ton compte.
+          </p>
+        </div>
+
+        <p className="text-muted-foreground text-xs">
+          Pas recu ?{' '}
+          <span className="text-foreground">
+            Verifie tes spams ou{' '}
+            <Link href="/register" className="text-primary hover:underline">
+              reessaie avec un autre email
+            </Link>
+          </span>
+        </p>
+      </div>
+
+      <p className="text-muted-foreground mt-8 text-center text-sm">
+        <Link href="/login" className="text-primary hover:underline">
+          Retour a la connexion
+        </Link>
+      </p>
+    </AuthShell>
+  )
+}

--- a/app/(protected)/client/page.tsx
+++ b/app/(protected)/client/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next'
+import { getSession } from '@/lib/auth'
+
+export const metadata: Metadata = {
+  title: 'Mon espace - CutBook',
+  description: 'Espace client CutBook.',
+}
+
+export default async function ClientPage() {
+  const session = await getSession()
+  const firstName = session?.user.name.split(' ')[0] ?? session?.user.name ?? 'client'
+
+  return (
+    <main className="bg-background min-h-svh px-6 py-10">
+      <div className="mx-auto max-w-3xl">
+        <p className="text-muted-foreground text-sm font-medium">Espace client</p>
+        <h1 className="mt-2 text-3xl font-black tracking-normal">Bonjour, {firstName}</h1>
+        <p className="text-muted-foreground mt-3 max-w-xl">
+          Votre espace client est pret a recevoir les prochaines pages de reservation et de suivi.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { getSession } from '@/lib/auth'
+
+export default async function ProtectedLayout({ children }: { children: ReactNode }) {
+  const session = await getSession()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  return children
+}

--- a/components/auth/auth-brand-panel.tsx
+++ b/components/auth/auth-brand-panel.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import { Scissors } from 'lucide-react'
+
+interface AuthBrandPanelProps {
+  title: string
+  highlight: string
+  description: string
+  stats?: Array<{
+    value: string
+    label: string
+  }>
+}
+
+export function AuthBrandPanel({ title, highlight, description, stats }: AuthBrandPanelProps) {
+  return (
+    <aside
+      className="hidden flex-col justify-between p-12 lg:flex lg:w-[45%]"
+      style={{ background: '#253122' }}
+    >
+      <Link href="/" className="flex items-center gap-2.5 transition-opacity hover:opacity-85">
+        <div
+          className="flex size-8 items-center justify-center rounded-lg"
+          style={{ background: '#489B6E' }}
+        >
+          <Scissors size={15} className="rotate-90 text-white" />
+        </div>
+        <span className="text-xl font-bold tracking-tight text-white">CutBook</span>
+      </Link>
+
+      <div>
+        <h2 className="text-2xl leading-tight font-black text-white">
+          {title}
+          <br />
+          <span style={{ color: '#C5A56E' }}>{highlight}</span>
+        </h2>
+        <p className="mt-4 text-sm" style={{ color: 'rgba(255,255,255,0.45)' }}>
+          {description}
+        </p>
+
+        {stats && (
+          <div className="mt-8 flex gap-6">
+            {stats.map((stat) => (
+              <div key={stat.label}>
+                <p className="text-xl font-black" style={{ color: '#C5A56E' }}>
+                  {stat.value}
+                </p>
+                <p className="mt-1 text-xs" style={{ color: 'rgba(255,255,255,0.45)' }}>
+                  {stat.label}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2" aria-hidden>
+        {['#253122', '#489B6E', '#C5A56E'].map((color) => (
+          <div
+            key={color}
+            className="size-3 rounded-full opacity-60"
+            style={{ background: color }}
+          />
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/components/auth/auth-shell.test.tsx
+++ b/components/auth/auth-shell.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AuthShell } from './auth-shell'
+
+describe('AuthShell', () => {
+  it('rend le shell auth avec le contenu de page sans navigation publique', () => {
+    render(
+      <AuthShell
+        title="Bon retour"
+        description="Connectez-vous pour acceder a votre espace."
+        brandTitle="Vos clients reservent"
+        brandHighlight="meme quand vous dormez."
+        brandDescription="Reservation en ligne et paiement securise."
+      >
+        <button type="button">Se connecter</button>
+      </AuthShell>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Bon retour' })).toBeInTheDocument()
+    expect(screen.getByText('Connectez-vous pour acceder a votre espace.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Se connecter' })).toBeInTheDocument()
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
+  })
+})

--- a/components/auth/auth-shell.tsx
+++ b/components/auth/auth-shell.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { Scissors } from 'lucide-react'
+import { AuthBrandPanel } from '@/components/auth/auth-brand-panel'
+
+interface AuthShellProps {
+  title: string
+  description?: string
+  brandTitle: string
+  brandHighlight: string
+  brandDescription: string
+  brandStats?: Array<{
+    value: string
+    label: string
+  }>
+  children: React.ReactNode
+}
+
+export function AuthShell({
+  title,
+  description,
+  brandTitle,
+  brandHighlight,
+  brandDescription,
+  brandStats,
+  children,
+}: AuthShellProps) {
+  return (
+    <div className="flex min-h-svh" style={{ background: '#f9f7f3' }}>
+      <AuthBrandPanel
+        title={brandTitle}
+        highlight={brandHighlight}
+        description={brandDescription}
+        stats={brandStats}
+      />
+
+      <main className="flex flex-1 flex-col items-center justify-center px-6 py-12">
+        <div className="w-full max-w-[360px]">
+          <Link href="/" className="mb-10 flex items-center gap-2 lg:hidden">
+            <div
+              className="flex size-7 items-center justify-center rounded-lg"
+              style={{ background: '#489B6E' }}
+            >
+              <Scissors size={13} className="rotate-90 text-white" />
+            </div>
+            <span className="font-bold tracking-tight" style={{ color: '#253122' }}>
+              CutBook
+            </span>
+          </Link>
+
+          <div className="mb-8">
+            <h1 className="text-2xl font-black tracking-tight" style={{ color: '#253122' }}>
+              {title}
+            </h1>
+            {description && <p className="text-muted-foreground mt-2 text-sm">{description}</p>}
+          </div>
+
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/auth/forgot-password-form.tsx
+++ b/components/auth/forgot-password-form.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { CheckCircle, Loader2 } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { authClient } from '@/lib/auth/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Email invalide'),
+})
+
+type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>
+
+export function ForgotPasswordForm() {
+  const [sent, setSent] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm<ForgotPasswordValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+  })
+
+  async function onSubmit(values: ForgotPasswordValues) {
+    setServerError(null)
+    setIsLoading(true)
+
+    await authClient.requestPasswordReset({
+      email: values.email,
+      redirectTo: '/reset-password',
+      fetchOptions: {
+        onResponse: (ctx: { response: Response }) => {
+          if (ctx.response.status === 429) {
+            setServerError('Trop de tentatives. Reessaie dans quelques secondes.')
+            setIsLoading(false)
+          }
+        },
+        onSuccess: () => {
+          setSent(true)
+          setIsLoading(false)
+        },
+        onError: () => {
+          setSent(true)
+          setIsLoading(false)
+        },
+      },
+    })
+  }
+
+  if (sent) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-4 text-center">
+        <CheckCircle className="text-primary size-12" />
+        <div>
+          <p className="font-semibold">Email envoye</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Si un compte existe pour{' '}
+            <span className="text-foreground font-medium">{getValues('email')}</span>, un lien de
+            reinitialisation sera envoye.
+          </p>
+        </div>
+        <Link href="/login" className="text-primary text-sm font-medium hover:underline">
+          Retour a la connexion
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="forgot-email">Adresse email</Label>
+        <Input
+          id="forgot-email"
+          type="email"
+          autoComplete="email"
+          placeholder="toi@exemple.fr"
+          aria-invalid={!!errors.email}
+          {...register('email')}
+        />
+        {errors.email && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-sm" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      <Button id="forgot-submit" type="submit" className="w-full" disabled={isLoading}>
+        {isLoading ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            Envoi en cours...
+          </>
+        ) : (
+          'Envoyer le lien'
+        )}
+      </Button>
+
+      <Link
+        href="/login"
+        className="text-muted-foreground hover:text-foreground text-center text-sm transition-colors"
+      >
+        Retour a la connexion
+      </Link>
+    </form>
+  )
+}

--- a/components/auth/login-form.test.tsx
+++ b/components/auth/login-form.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { LoginForm } from './login-form'
+
+const authMocks = vi.hoisted(() => ({
+  signInEmail: vi.fn(),
+  signInSocial: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/client', () => ({
+  signIn: {
+    email: authMocks.signInEmail,
+    social: authMocks.signInSocial,
+  },
+}))
+
+describe('LoginForm', () => {
+  it('connecte avec BetterAuth email et redirige vers /client en succes', async () => {
+    const user = userEvent.setup()
+    const originalLocation = window.location
+
+    authMocks.signInEmail.mockImplementation(async ({ fetchOptions }) => {
+      fetchOptions.onSuccess()
+    })
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: '' },
+    })
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText('Adresse email'), 'client@example.com')
+    await user.type(screen.getByLabelText('Mot de passe'), 'password-123')
+    await user.click(screen.getByRole('button', { name: 'Se connecter' }))
+
+    await waitFor(() => {
+      expect(authMocks.signInEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'client@example.com',
+          password: 'password-123',
+          fetchOptions: expect.objectContaining({
+            onSuccess: expect.any(Function),
+            onError: expect.any(Function),
+            onResponse: expect.any(Function),
+          }),
+        }),
+      )
+      expect(window.location.href).toBe('/client')
+    })
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+})

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import Link from 'next/link'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
+
+import { signIn } from '@/lib/auth/client'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+
+const loginSchema = z.object({
+  email: z.string().email('Email invalide'),
+  password: z.string().min(1, 'Mot de passe requis'),
+})
+
+type LoginFormValues = z.infer<typeof loginSchema>
+
+export function LoginForm() {
+  const [showPassword, setShowPassword] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+  })
+
+  async function onSubmit(values: LoginFormValues) {
+    setServerError(null)
+    setIsLoading(true)
+
+    await signIn.email({
+      email: values.email,
+      password: values.password,
+      fetchOptions: {
+        onResponse: (ctx) => {
+          // 429 = rate limit BetterAuth (brute force protection)
+          if (ctx.response.status === 429) {
+            setServerError('Trop de tentatives. Réessaie dans quelques secondes.')
+            setIsLoading(false)
+          }
+        },
+        onSuccess: () => {
+          // Cookie garanti écrit — redirect safe
+          window.location.href = '/client'
+        },
+        onError: () => {
+          setServerError('Email ou mot de passe incorrect.')
+          setIsLoading(false)
+        },
+      },
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+      {/* Email */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="login-email">Adresse email</Label>
+        <Input
+          id="login-email"
+          type="email"
+          autoComplete="email"
+          placeholder="toi@exemple.fr"
+          aria-invalid={!!errors.email}
+          {...register('email')}
+        />
+        {errors.email && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      {/* Password */}
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="login-password">Mot de passe</Label>
+          <Link
+            href="/forgot-password"
+            className="text-muted-foreground hover:text-primary text-xs transition-colors"
+          >
+            Mot de passe oublié ?
+          </Link>
+        </div>
+        <div className="relative">
+          <Input
+            id="login-password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="current-password"
+            placeholder="••••••••"
+            aria-invalid={!!errors.password}
+            className="pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+            onClick={() => setShowPassword((v) => !v)}
+            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+          >
+            {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+          </button>
+        </div>
+        {errors.password && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      {/* Erreur serveur */}
+      {serverError && (
+        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-sm" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      {/* Submit */}
+      <button
+        id="login-submit"
+        type="submit"
+        className="w-full rounded-xl py-3 text-sm font-bold text-white transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+        style={{ background: '#489B6E' }}
+        disabled={isLoading}
+      >
+        {isLoading ? (
+          <span className="flex items-center justify-center gap-2">
+            <Loader2 size={16} className="animate-spin" />
+            Connexion…
+          </span>
+        ) : (
+          'Se connecter'
+        )}
+      </button>
+
+      <Separator />
+
+      {/* Google OAuth */}
+      <button
+        id="login-google"
+        type="button"
+        className="flex w-full items-center justify-center gap-2.5 rounded-xl border py-3 text-sm font-medium transition-all hover:bg-black/5 active:scale-[0.98] disabled:opacity-50"
+        style={{ borderColor: 'rgba(37,49,34,0.15)', color: '#253122' }}
+        disabled={isLoading}
+        onClick={() =>
+          signIn.social({
+            provider: 'google',
+            callbackURL: '/client',
+          })
+        }
+      >
+        <svg viewBox="0 0 24 24" className="size-4" aria-hidden>
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        Continuer avec Google
+      </button>
+
+      <p className="text-muted-foreground text-center text-sm">
+        Pas encore de compte ?{' '}
+        <Link
+          href="/register"
+          className="font-semibold hover:underline"
+          style={{ color: '#489B6E' }}
+        >
+          Créer un compte
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import Link from 'next/link'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
+
+import { signUp, signIn } from '@/lib/auth/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+
+const registerSchema = z
+  .object({
+    name: z.string().min(2, 'Prénom et nom requis (2 caractères min)'),
+    email: z.string().email('Email invalide'),
+    password: z.string().min(8, '8 caractères minimum'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Les mots de passe ne correspondent pas',
+    path: ['confirmPassword'],
+  })
+
+type RegisterFormValues = z.infer<typeof registerSchema>
+
+export function RegisterForm() {
+  const [showPassword, setShowPassword] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+  })
+
+  async function onSubmit(values: RegisterFormValues) {
+    setServerError(null)
+    setIsLoading(true)
+
+    await signUp.email({
+      name: values.name,
+      email: values.email,
+      password: values.password,
+      fetchOptions: {
+        onResponse: (ctx) => {
+          if (ctx.response.status === 429) {
+            setServerError('Trop de tentatives. Réessaie dans quelques secondes.')
+            setIsLoading(false)
+          }
+          if (ctx.response.status === 422) {
+            setServerError('Un compte avec cet email existe déjà.')
+            setIsLoading(false)
+          }
+        },
+        onSuccess: () => {
+          // Redirect vers page de vérification email
+          window.location.href = '/verify-email'
+        },
+        onError: () => {
+          setServerError('Une erreur est survenue. Réessaie.')
+          setIsLoading(false)
+        },
+      },
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+      {/* Nom complet */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="register-name">Nom complet</Label>
+        <Input
+          id="register-name"
+          type="text"
+          autoComplete="name"
+          placeholder="Jean Dupont"
+          aria-invalid={!!errors.name}
+          {...register('name')}
+        />
+        {errors.name && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+
+      {/* Email */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="register-email">Adresse email</Label>
+        <Input
+          id="register-email"
+          type="email"
+          autoComplete="email"
+          placeholder="toi@exemple.fr"
+          aria-invalid={!!errors.email}
+          {...register('email')}
+        />
+        {errors.email && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      {/* Password */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="register-password">Mot de passe</Label>
+        <div className="relative">
+          <Input
+            id="register-password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="new-password"
+            placeholder="8 caractères minimum"
+            aria-invalid={!!errors.password}
+            className="pr-10"
+            {...register('password')}
+          />
+          <button
+            type="button"
+            aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+            onClick={() => setShowPassword((v) => !v)}
+            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+          >
+            {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+          </button>
+        </div>
+        {errors.password && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      {/* Confirm Password */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="register-confirm-password">Confirmer le mot de passe</Label>
+        <Input
+          id="register-confirm-password"
+          type={showPassword ? 'text' : 'password'}
+          autoComplete="new-password"
+          placeholder="••••••••"
+          aria-invalid={!!errors.confirmPassword}
+          {...register('confirmPassword')}
+        />
+        {errors.confirmPassword && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.confirmPassword.message}
+          </p>
+        )}
+      </div>
+
+      {/* Erreur serveur */}
+      {serverError && (
+        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-sm" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      {/* Submit */}
+      <Button id="register-submit" type="submit" className="w-full" disabled={isLoading}>
+        {isLoading ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            Création du compte…
+          </>
+        ) : (
+          'Créer mon compte'
+        )}
+      </Button>
+
+      <Separator />
+
+      {/* Google OAuth */}
+      <Button
+        id="register-google"
+        type="button"
+        variant="outline"
+        className="w-full"
+        disabled={isLoading}
+        onClick={() =>
+          signIn.social({
+            provider: 'google',
+            callbackURL: '/client',
+          })
+        }
+      >
+        <svg viewBox="0 0 24 24" className="size-4" aria-hidden>
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        Continuer avec Google
+      </Button>
+
+      <p className="text-muted-foreground text-center text-sm">
+        Déjà un compte ?{' '}
+        <Link href="/login" className="text-primary font-medium hover:underline">
+          Se connecter
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/components/auth/reset-password-form.tsx
+++ b/components/auth/reset-password-form.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useSearchParams } from 'next/navigation'
+import { CheckCircle, Loader2 } from 'lucide-react'
+import Link from 'next/link'
+
+import { authClient } from '@/lib/auth/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const resetSchema = z
+  .object({
+    password: z.string().min(8, '8 caractères minimum'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Les mots de passe ne correspondent pas',
+    path: ['confirmPassword'],
+  })
+
+type ResetFormValues = z.infer<typeof resetSchema>
+
+export function ResetPasswordForm() {
+  const searchParams = useSearchParams()
+  // Le token est passé en query param par BetterAuth dans le lien email
+  const token = searchParams.get('token') ?? ''
+
+  const [done, setDone] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetFormValues>({
+    resolver: zodResolver(resetSchema),
+  })
+
+  async function onSubmit(values: ResetFormValues) {
+    setServerError(null)
+    setIsLoading(true)
+
+    await authClient.resetPassword({
+      token,
+      newPassword: values.password,
+      fetchOptions: {
+        onResponse: (ctx) => {
+          if (ctx.response.status === 400) {
+            setServerError('Lien expiré ou invalide. Refais une demande de réinitialisation.')
+            setIsLoading(false)
+          }
+        },
+        onSuccess: () => {
+          setDone(true)
+          setIsLoading(false)
+        },
+        onError: () => {
+          setServerError('Une erreur est survenue. Réessaie.')
+          setIsLoading(false)
+        },
+      },
+    })
+  }
+
+  if (!token) {
+    return (
+      <div className="space-y-3 text-center">
+        <p className="text-destructive text-sm">Lien de réinitialisation invalide.</p>
+        <Link href="/forgot-password" className="text-primary text-sm hover:underline">
+          Faire une nouvelle demande
+        </Link>
+      </div>
+    )
+  }
+
+  if (done) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-4 text-center">
+        <CheckCircle className="text-primary size-12" />
+        <div>
+          <p className="font-semibold">Mot de passe modifié !</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Tu peux maintenant te connecter avec ton nouveau mot de passe.
+          </p>
+        </div>
+        <Link href="/login" className="text-primary text-sm font-medium hover:underline">
+          Se connecter
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="reset-password">Nouveau mot de passe</Label>
+        <Input
+          id="reset-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="8 caractères minimum"
+          aria-invalid={!!errors.password}
+          {...register('password')}
+        />
+        {errors.password && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="reset-confirm-password">Confirmer le mot de passe</Label>
+        <Input
+          id="reset-confirm-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="••••••••"
+          aria-invalid={!!errors.confirmPassword}
+          {...register('confirmPassword')}
+        />
+        {errors.confirmPassword && (
+          <p className="text-destructive text-xs" role="alert">
+            {errors.confirmPassword.message}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-sm" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      <Button id="reset-submit" type="submit" className="w-full" disabled={isLoading}>
+        {isLoading ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            Modification…
+          </>
+        ) : (
+          'Modifier mon mot de passe'
+        )}
+      </Button>
+    </form>
+  )
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring aria-invalid:border-destructive aria-invalid:ring-destructive/20 flex h-10 w-full rounded-lg border px-3 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+function Label({ className, ...props }: React.ComponentProps<'label'>) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        'text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: 'horizontal' | 'vertical'
+  decorative?: boolean
+}
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: SeparatorProps) {
+  return (
+    <div
+      role={decorative ? 'none' : 'separator'}
+      aria-orientation={decorative ? undefined : orientation}
+      data-orientation={orientation}
+      className={cn(
+        'bg-border shrink-0',
+        orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
 # Progress — CutBook V2
 
 > Suivi de l'avancement du projet ligne par ligne (vs `02-planning-4-semaines.md`).
-> Mis a jour : 6 mai 2026 (merge Prisma/Neon + CI Vercel).
+> Mis a jour : 7 mai 2026 (auth-flow depuis dev).
 
 **Legende**
 
@@ -30,14 +30,14 @@
 
 ### Adil
 
-| J        | Tache                                                                          | Status | Comment                                                                                                                                                              |
-| -------- | ------------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| J1 (lun) | Onboarding : cloner repo, setup env local, comprendre la structure             | ✅     | `docs/onboarding.md` cree (25 min de lecture, pedagogique : stack, raison de chaque techno, workflow git, conventions kebab-case). Adil pourra demarrer lundi 6 mai. |
-| J2-J3    | Pages auth UI : login, register, forgot password, verify email, reset password | 🔴     | Pas commence.                                                                                                                                                        |
-| J4       | Landing page publique                                                          | 🟡     | Prototype CutBook deja en place dans `app/page.tsx` (plus de boilerplate Next.js). Reste a finaliser le contenu/CTA selon la version demo.                           |
-| J5       | Dashboard client : layout + page d'accueil + navigation                        | 🔴     | Pas commence.                                                                                                                                                        |
-| J6       | Dashboard membre : layout + page d'accueil + navigation                        | 🔴     | Pas commence.                                                                                                                                                        |
-| J7       | Integration auth UI + BetterAuth                                               | 🔴     | Pas commence.                                                                                                                                                        |
+| J        | Tache                                                                          | Status | Comment                                                                                                                                                                |
+| -------- | ------------------------------------------------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| J1 (lun) | Onboarding : cloner repo, setup env local, comprendre la structure             | ✅     | `docs/onboarding.md` cree (25 min de lecture, pedagogique : stack, raison de chaque techno, workflow git, conventions kebab-case). Adil pourra demarrer lundi 6 mai.   |
+| J2-J3    | Pages auth UI : login, register, forgot password, verify email, reset password | ✅     | Branche `auth-flow` : routes `app/(auth)/*`, shell auth partage, formulaires BetterAuth email/password + Google OAuth, tests de regression `AuthShell` et `LoginForm`. |
+| J4       | Landing page publique                                                          | 🟡     | Prototype CutBook deja en place dans `app/page.tsx` (plus de boilerplate Next.js). Reste a finaliser le contenu/CTA selon la version demo.                             |
+| J5       | Dashboard client : layout + page d'accueil + navigation                        | 🔴     | Pas commence.                                                                                                                                                          |
+| J6       | Dashboard membre : layout + page d'accueil + navigation                        | 🔴     | Pas commence.                                                                                                                                                          |
+| J7       | Integration auth UI + BetterAuth                                               | 🟡     | Login email/password branche via BetterAuth sans tRPC et redirige vers `/client`. `app/(protected)/client/page.tsx` minimal ajoute pour valider le flow.               |
 
 ### Taches transverses S1 (bonus)
 
@@ -55,7 +55,7 @@
 ### Livrable S1 (objectif)
 
 - 🔴 Projet deploye sur Vercel (meme basique)
-- 🟡 Auth fonctionnelle (backend pret, manque le middleware + UI)
+- 🟡 Auth fonctionnelle (backend + UI auth, protection layout `(protected)` minimale, reste roles/member/owner)
 - 🟡 Schema BDD complet (sur Neon : a faire / sur Docker local : ok)
 - 🔴 Layouts client + coiffeur en place
 

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -11,3 +11,5 @@ const authClient = createAuthClient({
 })
 
 export const { signIn, signUp, signOut, useSession } = authClient
+
+export { authClient }


### PR DESCRIPTION
## Summary
- add the `(auth)` route group with shared auth shell
- add BetterAuth email/password forms and Google OAuth entrypoints
- add minimal protected `/client` destination for successful login
- update `docs/progress.md`

## Checks
- pnpm lint
- pnpm typecheck
- pnpm test
- pre-push: typecheck, lint, unit tests, integration tests, build:check