### PR TITLE
feat: client dashboard data

### DIFF
--- a/app/(protected)/client/bookings/page.tsx
+++ b/app/(protected)/client/bookings/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { ClientBookingsView } from '@/components/dashboard/client-bookings-view'
+
+export const metadata: Metadata = {
+  title: 'Mes reservations - CutBook',
+}
+
+export default function ClientBookingsPage() {
+  return <ClientBookingsView />
+}

--- a/app/(protected)/client/history/page.tsx
+++ b/app/(protected)/client/history/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { ClientHistoryView } from '@/components/dashboard/client-history-view'
+
+export const metadata: Metadata = {
+  title: 'Historique - CutBook',
+}
+
+export default function ClientHistoryPage() {
+  return <ClientHistoryView />
+}

--- a/app/(protected)/client/layout.tsx
+++ b/app/(protected)/client/layout.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+import { getSession } from '@/lib/auth'
+import { DashboardBreadcrumb } from '@/components/dashboard/dashboard-breadcrumb'
+import { ClientSidebar } from '@/components/dashboard/client-sidebar'
+import { Search } from 'lucide-react'
+import Link from 'next/link'
+
+export default async function ClientLayout({ children }: { children: ReactNode }) {
+  const session = await getSession()
+  const name = session!.user.name
+  const firstName = name.split(' ')[0] ?? name
+  const displayName = firstName.charAt(0).toUpperCase() + firstName.slice(1)
+  const initials = name
+    .split(' ')
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .slice(0, 2)
+    .join('')
+
+  return (
+    <div className="flex" style={{ minHeight: '100svh', background: '#f9f7f3' }}>
+      {/* Suspense évite l'hydration mismatch de usePathname() dans ClientSidebar */}
+      <Suspense
+        fallback={
+          <aside
+            className="flex w-60 shrink-0 flex-col"
+            style={{ background: '#253122' }}
+            aria-hidden
+          />
+        }
+      >
+        <ClientSidebar />
+      </Suspense>
+
+      {/* Zone contenu — min-w-0 empêche le shrink, flex-1 prend tout l'espace restant */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        {/* Header */}
+        <header
+          style={{
+            display: 'flex',
+            height: '4rem',
+            flexShrink: 0,
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderBottom: '1px solid rgba(37,49,34,0.08)',
+            background: '#fff',
+            padding: '0 2rem',
+          }}
+        >
+          <p style={{ fontWeight: 600, fontSize: '0.9375rem', color: '#253122' }}>
+            Bonjour, {displayName} 👋
+          </p>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <Link
+              id="client-header-search"
+              href="/search"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                background: '#489B6E',
+                color: '#fff',
+                padding: '0.5rem 1rem',
+                borderRadius: '0.5rem',
+                fontSize: '0.875rem',
+                fontWeight: 700,
+                textDecoration: 'none',
+              }}
+            >
+              <Search size={14} />
+              Trouver un pro
+            </Link>
+            <div
+              style={{
+                width: '2.25rem',
+                height: '2.25rem',
+                flexShrink: 0,
+                borderRadius: '50%',
+                background: '#253122',
+                color: '#fff',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '0.75rem',
+                fontWeight: 700,
+              }}
+              title={name}
+            >
+              {initials}
+            </div>
+          </div>
+        </header>
+
+        {/* Main — prend tout l'espace vertical restant, scroll si besoin */}
+        <main
+          style={{
+            flex: 1,
+            overflow: 'auto',
+            padding: '2rem 2.5rem',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
+        >
+          <Suspense fallback={null}>
+            <DashboardBreadcrumb base="client" />
+          </Suspense>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/app/(protected)/client/page.tsx
+++ b/app/(protected)/client/page.tsx
@@ -1,24 +1,11 @@
 import type { Metadata } from 'next'
-import { getSession } from '@/lib/auth'
+import { ClientDashboardOverview } from '@/components/dashboard/client-dashboard-overview'
 
 export const metadata: Metadata = {
   title: 'Mon espace - CutBook',
-  description: 'Espace client CutBook.',
+  description: 'Gerez vos reservations et consultez votre programme de fidelite.',
 }
 
-export default async function ClientPage() {
-  const session = await getSession()
-  const firstName = session?.user.name.split(' ')[0] ?? session?.user.name ?? 'client'
-
-  return (
-    <main className="bg-background min-h-svh px-6 py-10">
-      <div className="mx-auto max-w-3xl">
-        <p className="text-muted-foreground text-sm font-medium">Espace client</p>
-        <h1 className="mt-2 text-3xl font-black tracking-normal">Bonjour, {firstName}</h1>
-        <p className="text-muted-foreground mt-3 max-w-xl">
-          Votre espace client est pret a recevoir les prochaines pages de reservation et de suivi.
-        </p>
-      </div>
-    </main>
-  )
+export default function ClientDashboardPage() {
+  return <ClientDashboardOverview />
 }

--- a/app/(protected)/client/rewards/page.tsx
+++ b/app/(protected)/client/rewards/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { ClientRewardsView } from '@/components/dashboard/client-rewards-view'
+
+export const metadata: Metadata = {
+  title: 'Programme fidelite - CutBook',
+}
+
+export default function ClientRewardsPage() {
+  return <ClientRewardsView />
+}

--- a/app/(protected)/client/settings/page.tsx
+++ b/app/(protected)/client/settings/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { getSession } from '@/lib/auth'
-import { SettingsClient } from './settings-client'
+import { ClientSettingsView } from '@/components/dashboard/client-settings-view'
 
 export const metadata: Metadata = {
   title: 'Paramètres — CutBook',
@@ -12,5 +12,5 @@ export default async function ClientSettingsPage() {
   const session = await getSession()
   const email = session!.user.email
 
-  return <SettingsClient currentEmail={email} />
+  return <ClientSettingsView currentEmail={email} />
 }

--- a/app/(protected)/client/settings/page.tsx
+++ b/app/(protected)/client/settings/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import { getSession } from '@/lib/auth'
+import { SettingsClient } from './settings-client'
+
+export const metadata: Metadata = {
+  title: 'Paramètres — CutBook',
+  description: 'Gérez vos informations personnelles et la sécurité de votre compte.',
+}
+
+export default async function ClientSettingsPage() {
+  // getSession() est cachée (React.cache) — 0 requête supplémentaire vs le layout
+  const session = await getSession()
+  const email = session!.user.email
+
+  return <SettingsClient currentEmail={email} />
+}

--- a/app/(protected)/client/settings/settings-client.tsx
+++ b/app/(protected)/client/settings/settings-client.tsx
@@ -1,0 +1,424 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import {
+  Mail,
+  Lock,
+  Phone,
+  Trash2,
+  Save,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+} from 'lucide-react'
+import { authClient } from '@/lib/auth/client'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Status = { type: 'success' | 'error'; message: string } | null
+
+// ── Section wrapper ────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-2xl border"
+      style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+    >
+      <div className="border-b px-6 py-4" style={{ borderColor: 'rgba(37,49,34,0.06)' }}>
+        <h2 className="text-sm font-bold" style={{ color: '#253122' }}>
+          {title}
+        </h2>
+        <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+          {subtitle}
+        </p>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  )
+}
+
+// ── Input ──────────────────────────────────────────────────────────────────────
+
+function Field({
+  label,
+  id,
+  type = 'text',
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  suffix,
+}: {
+  label: string
+  id: string
+  type?: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  disabled?: boolean
+  suffix?: React.ReactNode
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1.5 block text-xs font-medium"
+        style={{ color: 'rgba(37,49,34,0.6)' }}
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={type}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="w-full rounded-xl border px-3 py-2.5 text-sm transition-colors outline-none focus:ring-1 disabled:opacity-50"
+          style={{
+            borderColor: 'rgba(37,49,34,0.15)',
+            color: '#253122',
+            background: disabled ? 'rgba(37,49,34,0.02)' : '#fff',
+          }}
+        />
+        {suffix && <div className="absolute inset-y-0 right-3 flex items-center">{suffix}</div>}
+      </div>
+    </div>
+  )
+}
+
+// ── Toast inline ───────────────────────────────────────────────────────────────
+
+function Toast({ status }: { status: Status }) {
+  if (!status) return null
+  return (
+    <div
+      className="flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-medium"
+      style={
+        status.type === 'success'
+          ? { background: 'rgba(72,155,110,0.1)', color: '#489B6E' }
+          : { background: 'rgba(220,38,38,0.08)', color: '#dc2626' }
+      }
+    >
+      {status.type === 'success' ? <CheckCircle2 size={15} /> : <AlertCircle size={15} />}
+      {status.message}
+    </div>
+  )
+}
+
+// ── Submit button ──────────────────────────────────────────────────────────────
+
+function SubmitBtn({ pending, label = 'Enregistrer' }: { pending: boolean; label?: string }) {
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-85 disabled:opacity-60"
+      style={{ background: '#489B6E' }}
+    >
+      {pending ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+      {label}
+    </button>
+  )
+}
+
+// ── Email section ──────────────────────────────────────────────────────────────
+
+function EmailSection({ currentEmail }: { currentEmail: string }) {
+  const [email, setEmail] = useState(currentEmail)
+  const [password, setPassword] = useState('')
+  const [status, setStatus] = useState<Status>(null)
+  const [pending, startTransition] = useTransition()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus(null)
+    startTransition(async () => {
+      const res = await authClient.changeEmail({ newEmail: email, callbackURL: '/client/settings' })
+      if (res.error) {
+        setStatus({
+          type: 'error',
+          message: res.error.message ?? "Erreur lors du changement d'email.",
+        })
+      } else {
+        setStatus({ type: 'success', message: 'Un email de confirmation a été envoyé.' })
+        setPassword('')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Field
+        id="settings-email"
+        label="Nouvelle adresse email"
+        type="email"
+        value={email}
+        onChange={setEmail}
+        placeholder="exemple@email.com"
+        suffix={<Mail size={14} style={{ color: 'rgba(37,49,34,0.3)' }} />}
+      />
+      <Toast status={status} />
+      <SubmitBtn pending={pending} />
+    </form>
+  )
+}
+
+// ── Password section ───────────────────────────────────────────────────────────
+
+function PasswordSection() {
+  const [current, setCurrent] = useState('')
+  const [next, setNext] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [show, setShow] = useState(false)
+  const [status, setStatus] = useState<Status>(null)
+  const [pending, startTransition] = useTransition()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus(null)
+    if (next !== confirm) {
+      setStatus({ type: 'error', message: 'Les mots de passe ne correspondent pas.' })
+      return
+    }
+    if (next.length < 8) {
+      setStatus({ type: 'error', message: 'Le mot de passe doit faire au moins 8 caractères.' })
+      return
+    }
+    startTransition(async () => {
+      const res = await authClient.changePassword({
+        currentPassword: current,
+        newPassword: next,
+        revokeOtherSessions: true,
+      })
+      if (res.error) {
+        setStatus({ type: 'error', message: res.error.message ?? 'Mot de passe actuel incorrect.' })
+      } else {
+        setStatus({ type: 'success', message: 'Mot de passe mis à jour avec succès.' })
+        setCurrent('')
+        setNext('')
+        setConfirm('')
+      }
+    })
+  }
+
+  const toggleIcon = show ? (
+    <EyeOff
+      size={14}
+      style={{ color: 'rgba(37,49,34,0.3)', cursor: 'pointer' }}
+      onClick={() => setShow(false)}
+    />
+  ) : (
+    <Eye
+      size={14}
+      style={{ color: 'rgba(37,49,34,0.3)', cursor: 'pointer' }}
+      onClick={() => setShow(true)}
+    />
+  )
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Field
+        id="settings-current-pw"
+        label="Mot de passe actuel"
+        type={show ? 'text' : 'password'}
+        value={current}
+        onChange={setCurrent}
+        suffix={toggleIcon}
+      />
+      <Field
+        id="settings-new-pw"
+        label="Nouveau mot de passe"
+        type={show ? 'text' : 'password'}
+        value={next}
+        onChange={setNext}
+        placeholder="8 caractères minimum"
+      />
+      <Field
+        id="settings-confirm-pw"
+        label="Confirmer le nouveau mot de passe"
+        type={show ? 'text' : 'password'}
+        value={confirm}
+        onChange={setConfirm}
+      />
+      <Toast status={status} />
+      <SubmitBtn pending={pending} />
+    </form>
+  )
+}
+
+// ── Phone section ──────────────────────────────────────────────────────────────
+
+function PhoneSection() {
+  const [phone, setPhone] = useState('')
+  const [status, setStatus] = useState<Status>(null)
+  const [pending, startTransition] = useTransition()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus(null)
+    // TODO Samy S2 : tRPC user.updatePhone({ phone })
+    startTransition(async () => {
+      await new Promise((r) => setTimeout(r, 600)) // mock
+      setStatus({ type: 'success', message: 'Numéro enregistré (intégration tRPC en S2).' })
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Field
+        id="settings-phone"
+        label="Numéro de téléphone"
+        type="tel"
+        value={phone}
+        onChange={setPhone}
+        placeholder="+33 6 12 34 56 78"
+        suffix={<Phone size={14} style={{ color: 'rgba(37,49,34,0.3)' }} />}
+      />
+      <Toast status={status} />
+      <SubmitBtn pending={pending} />
+    </form>
+  )
+}
+
+// ── Delete account section ─────────────────────────────────────────────────────
+
+function DeleteSection() {
+  const [confirm, setConfirm] = useState('')
+  const [step, setStep] = useState<'idle' | 'confirm'>('idle')
+  const [status, setStatus] = useState<Status>(null)
+  const [pending, startTransition] = useTransition()
+
+  const CONFIRM_WORD = 'SUPPRIMER'
+
+  function handleDelete() {
+    startTransition(async () => {
+      const res = await authClient.deleteUser({ callbackURL: '/login' })
+      if (res.error) {
+        setStatus({ type: 'error', message: res.error.message ?? 'Erreur lors de la suppression.' })
+      } else {
+        window.location.href = '/login'
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="rounded-xl border p-4"
+        style={{ borderColor: 'rgba(220,38,38,0.15)', background: 'rgba(220,38,38,0.04)' }}
+      >
+        <p className="text-sm font-semibold" style={{ color: '#dc2626' }}>
+          Cette action est irréversible
+        </p>
+        <p className="mt-1 text-xs" style={{ color: 'rgba(37,49,34,0.55)' }}>
+          Toutes vos données (réservations, points fidélité, historique) seront définitivement
+          supprimées.
+        </p>
+      </div>
+
+      {step === 'idle' ? (
+        <button
+          type="button"
+          onClick={() => setStep('confirm')}
+          className="flex items-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-bold transition-colors hover:bg-red-50"
+          style={{ borderColor: 'rgba(220,38,38,0.3)', color: '#dc2626' }}
+        >
+          <Trash2 size={14} />
+          Supprimer mon compte
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm" style={{ color: '#253122' }}>
+            Tapez <strong>{CONFIRM_WORD}</strong> pour confirmer :
+          </p>
+          <input
+            id="settings-delete-confirm"
+            type="text"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            placeholder={CONFIRM_WORD}
+            className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+            style={{ borderColor: 'rgba(220,38,38,0.3)', color: '#253122' }}
+          />
+          <Toast status={status} />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={confirm !== CONFIRM_WORD || pending}
+              className="flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-85 disabled:opacity-40"
+              style={{ background: '#dc2626' }}
+            >
+              {pending ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+              Confirmer la suppression
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setStep('idle')
+                setConfirm('')
+              }}
+              className="rounded-xl border px-5 py-2.5 text-sm font-medium transition-colors hover:bg-black/[.02]"
+              style={{ borderColor: 'rgba(37,49,34,0.12)', color: 'rgba(37,49,34,0.6)' }}
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Page principale ────────────────────────────────────────────────────────────
+
+interface SettingsClientProps {
+  currentEmail: string
+}
+
+export function SettingsClient({ currentEmail }: SettingsClientProps) {
+  return (
+    <div className="w-full max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-xl font-black" style={{ color: '#253122' }}>
+          Paramètres du compte
+        </h1>
+        <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+          Gérez vos informations personnelles et la sécurité de votre compte.
+        </p>
+      </div>
+
+      <Section title="Adresse email" subtitle="Modifier l'email associé à votre compte.">
+        <EmailSection currentEmail={currentEmail} />
+      </Section>
+
+      <Section title="Mot de passe" subtitle="Choisissez un mot de passe fort et unique.">
+        <PasswordSection />
+      </Section>
+
+      <Section title="Numéro de téléphone" subtitle="Pour les rappels de rendez-vous par SMS.">
+        <PhoneSection />
+      </Section>
+
+      <Section
+        title="Supprimer le compte"
+        subtitle="Suppression définitive de votre compte et de toutes vos données."
+      >
+        <DeleteSection />
+      </Section>
+    </div>
+  )
+}

--- a/app/(protected)/member/availability/page.tsx
+++ b/app/(protected)/member/availability/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import { Clock } from 'lucide-react'
+import { MemberPlaceholderView } from '@/components/dashboard/member-placeholder-view'
+
+export const metadata: Metadata = { title: 'Mes creneaux - CutBook' }
+
+export default function MemberAvailabilityPage() {
+  return (
+    <MemberPlaceholderView
+      title="Mes creneaux"
+      icon={Clock}
+      headline="Gestion des creneaux - en cours d'implementation"
+      description="La gestion des disponibilites sera implementee ici (J14)."
+    />
+  )
+}

--- a/app/(protected)/member/calendar/page.tsx
+++ b/app/(protected)/member/calendar/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import { CalendarDays } from 'lucide-react'
+import { MemberPlaceholderView } from '@/components/dashboard/member-placeholder-view'
+
+export const metadata: Metadata = { title: 'Mon calendrier - CutBook' }
+
+export default function MemberCalendarPage() {
+  return (
+    <MemberPlaceholderView
+      title="Mon calendrier"
+      icon={CalendarDays}
+      headline="Calendrier - en cours d'implementation"
+      description="FullCalendar sera integre ici (J13)."
+    />
+  )
+}

--- a/app/(protected)/member/layout.tsx
+++ b/app/(protected)/member/layout.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+import { DashboardBreadcrumb } from '@/components/dashboard/dashboard-breadcrumb'
+import { MemberSidebar } from '@/components/dashboard/member-sidebar'
+
+// Shell partagé pour toutes les pages /member/* : /member, /member/calendar, /member/availability...
+// (dashboard)/layout.tsx gère la protection session.
+export default function MemberLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex" style={{ minHeight: '100svh', background: '#f9f7f3' }}>
+      {/* Suspense évite l'hydration mismatch de usePathname() dans MemberSidebar */}
+      <Suspense
+        fallback={
+          <aside
+            className="flex w-64 shrink-0 flex-col"
+            style={{ background: '#253122' }}
+            aria-hidden
+          />
+        }
+      >
+        <MemberSidebar />
+      </Suspense>
+
+      <main
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: 'auto',
+          padding: '2rem 2.5rem',
+          width: '100%',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Suspense fallback={null}>
+          <DashboardBreadcrumb base="member" />
+        </Suspense>
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/app/(protected)/member/page.tsx
+++ b/app/(protected)/member/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { MemberDashboardOverview } from '@/components/dashboard/member-dashboard-overview'
+
+export const metadata: Metadata = {
+  title: 'Espace professionnel - CutBook',
+}
+
+export default function MemberDashboardPage() {
+  return <MemberDashboardOverview />
+}

--- a/app/(protected)/member/profile/page.tsx
+++ b/app/(protected)/member/profile/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import { User } from 'lucide-react'
+import { MemberPlaceholderView } from '@/components/dashboard/member-placeholder-view'
+
+export const metadata: Metadata = { title: 'Mon profil - CutBook' }
+
+export default function MemberProfilePage() {
+  return (
+    <MemberPlaceholderView
+      title="Mon profil"
+      icon={User}
+      headline="Profil - en cours d'implementation"
+      description="Gestion du profil professionnel (bio, specialites, photo)."
+    />
+  )
+}

--- a/app/(public)/[org-slug]/booking/slot/page.tsx
+++ b/app/(public)/[org-slug]/booking/slot/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default async function PublicBookingSlotPage({ params, searchParams }: Props) {
   const { 'org-slug': orgSlug } = await params
   const { service, member } = await searchParams
-  const slots = await listPublicOrganizationAvailableSlots(orgSlug)
+  const slots = await listPublicOrganizationAvailableSlots(orgSlug, { memberId: member })
   const slotDates = listPublicSlotDates(slots)
   const publicSlots = slots.map((slot) => ({
     id: slot.id,

--- a/components/booking/confirm-booking-form.test.tsx
+++ b/components/booking/confirm-booking-form.test.tsx
@@ -44,7 +44,7 @@ describe('ConfirmBookingForm', () => {
     )
   })
 
-  it('redirige vers le client cinq secondes apres confirmation', async () => {
+  it('redirige vers les reservations client cinq secondes apres confirmation', async () => {
     render(
       <ConfirmBookingForm orgSlug="atelier-nova" serviceId="s1" memberId="m1" slotId="slot-1" />,
     )
@@ -53,6 +53,6 @@ describe('ConfirmBookingForm', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Reservation confirmee.')
 
     await vi.advanceTimersByTimeAsync(5000)
-    expect(routerReplace).toHaveBeenCalledWith('/client')
+    expect(routerReplace).toHaveBeenCalledWith('/client/bookings')
   })
 })

--- a/components/booking/confirm-booking-form.tsx
+++ b/components/booking/confirm-booking-form.tsx
@@ -28,7 +28,7 @@ export function ConfirmBookingForm({
     }
 
     const timeout = window.setTimeout(() => {
-      router.replace('/client')
+      router.replace('/client/bookings')
     }, 5000)
 
     return () => window.clearTimeout(timeout)

--- a/components/dashboard/client-bookings-view.tsx
+++ b/components/dashboard/client-bookings-view.tsx
@@ -1,7 +1,9 @@
+'use client'
+
 import { CalendarDays, ChevronRight, Clock, Plus, X } from 'lucide-react'
 import Link from 'next/link'
-
-type BookingStatus = 'PENDING' | 'CONFIRMED' | 'CANCELLED'
+import type { BookingStatus } from '@/generated/prisma/enums'
+import { trpc } from '@/lib/trpc/client'
 
 interface ClientBooking {
   id: string
@@ -17,20 +19,18 @@ interface ClientBooking {
 const statusLabels: Record<BookingStatus, string> = {
   PENDING: 'En attente',
   CONFIRMED: 'Confirme',
+  COMPLETED: 'Termine',
   CANCELLED: 'Annule',
 }
 
 const statusStyles = {
   PENDING: { background: 'rgba(197,165,110,0.12)', color: '#C5A56E' },
   CONFIRMED: { background: 'rgba(72,155,110,0.12)', color: '#489B6E' },
+  COMPLETED: { background: 'rgba(72,155,110,0.1)', color: '#489B6E' },
   CANCELLED: { background: 'rgba(37,49,34,0.08)', color: 'rgba(37,49,34,0.4)' },
 } satisfies Record<BookingStatus, { background: string; color: string }>
 
-interface ClientBookingsViewProps {
-  bookings?: ClientBooking[]
-}
-
-export function ClientBookingsView({ bookings = [] }: ClientBookingsViewProps) {
+function ClientBookingsContent({ bookings }: { bookings: ClientBooking[] }) {
   const upcoming = bookings.filter((booking) => booking.status !== 'CANCELLED')
   const totalSpent = bookings
     .filter((booking) => booking.status === 'CONFIRMED')
@@ -176,4 +176,40 @@ export function ClientBookingsView({ bookings = [] }: ClientBookingsViewProps) {
       </div>
     </div>
   )
+}
+
+export function ClientBookingsView() {
+  const bookings = trpc.clientPortal.upcomingBookings.useQuery()
+
+  if (bookings.isLoading) {
+    return (
+      <div
+        className="rounded-2xl border p-8 text-sm"
+        style={{
+          borderColor: 'rgba(37,49,34,0.08)',
+          background: '#fff',
+          color: 'rgba(37,49,34,0.55)',
+        }}
+      >
+        Chargement des reservations...
+      </div>
+    )
+  }
+
+  if (bookings.isError) {
+    return (
+      <div
+        className="rounded-2xl border p-8 text-sm"
+        style={{
+          borderColor: 'rgba(220,38,38,0.18)',
+          background: 'rgba(220,38,38,0.04)',
+          color: '#dc2626',
+        }}
+      >
+        Impossible de charger vos reservations.
+      </div>
+    )
+  }
+
+  return <ClientBookingsContent bookings={bookings.data ?? []} />
 }

--- a/components/dashboard/client-bookings-view.tsx
+++ b/components/dashboard/client-bookings-view.tsx
@@ -1,0 +1,179 @@
+import { CalendarDays, ChevronRight, Clock, Plus, X } from 'lucide-react'
+import Link from 'next/link'
+
+type BookingStatus = 'PENDING' | 'CONFIRMED' | 'CANCELLED'
+
+interface ClientBooking {
+  id: string
+  org: string
+  service: string
+  member: string
+  date: string
+  time: string
+  price: number
+  status: BookingStatus
+}
+
+const statusLabels: Record<BookingStatus, string> = {
+  PENDING: 'En attente',
+  CONFIRMED: 'Confirme',
+  CANCELLED: 'Annule',
+}
+
+const statusStyles = {
+  PENDING: { background: 'rgba(197,165,110,0.12)', color: '#C5A56E' },
+  CONFIRMED: { background: 'rgba(72,155,110,0.12)', color: '#489B6E' },
+  CANCELLED: { background: 'rgba(37,49,34,0.08)', color: 'rgba(37,49,34,0.4)' },
+} satisfies Record<BookingStatus, { background: string; color: string }>
+
+interface ClientBookingsViewProps {
+  bookings?: ClientBooking[]
+}
+
+export function ClientBookingsView({ bookings = [] }: ClientBookingsViewProps) {
+  const upcoming = bookings.filter((booking) => booking.status !== 'CANCELLED')
+  const totalSpent = bookings
+    .filter((booking) => booking.status === 'CONFIRMED')
+    .reduce((sum, booking) => sum + booking.price, 0)
+
+  return (
+    <div className="w-full space-y-6">
+      <div className="flex justify-end">
+        <Link
+          href="/search"
+          className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-85"
+          style={{ background: '#489B6E' }}
+        >
+          <Plus size={14} />
+          Nouveau RDV
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+        <aside className="space-y-4 lg:col-span-1">
+          <div
+            className="rounded-2xl border p-5"
+            style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+          >
+            <p
+              className="mb-3 text-xs font-semibold tracking-widest uppercase"
+              style={{ color: 'rgba(37,49,34,0.4)' }}
+            >
+              Resume
+            </p>
+            <div className="space-y-4">
+              <div>
+                <p className="text-3xl font-black" style={{ color: '#253122' }}>
+                  {upcoming.length}
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  RDV a venir
+                </p>
+              </div>
+              <div className="border-t pt-4" style={{ borderColor: 'rgba(37,49,34,0.06)' }}>
+                <p className="text-3xl font-black" style={{ color: '#253122' }}>
+                  {totalSpent} EUR
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  Depense au total
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <Link
+            href="/client/history"
+            className="flex items-center justify-between rounded-2xl border px-4 py-3.5 text-sm transition-colors hover:bg-black/[.02]"
+            style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+          >
+            <span style={{ color: 'rgba(37,49,34,0.55)' }}>Historique complet</span>
+            <ChevronRight size={14} style={{ color: 'rgba(37,49,34,0.25)' }} />
+          </Link>
+        </aside>
+
+        <section className="lg:col-span-3" aria-labelledby="upcoming-bookings-heading">
+          {/*<h1 id="upcoming-bookings-heading" className="mb-4 text-lg font-black" style={{ color: '#253122' }}>
+            A venir
+          </h1>*/}
+          {upcoming.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center rounded-2xl border p-16 text-center"
+              style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff', minHeight: '280px' }}
+            >
+              <CalendarDays size={40} className="mb-4" style={{ color: 'rgba(37,49,34,0.12)' }} />
+              <p className="font-semibold" style={{ color: '#253122' }}>
+                Aucune reservation a venir
+              </p>
+              <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                Prenez un RDV en quelques secondes.
+              </p>
+              <Link
+                id="bookings-cta"
+                href="/search"
+                className="mt-5 inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90"
+                style={{ background: '#489B6E' }}
+              >
+                Trouver un professionnel
+              </Link>
+            </div>
+          ) : (
+            <ol className="space-y-3" aria-label="Liste de vos reservations">
+              {upcoming.map((booking) => (
+                <li
+                  key={booking.id}
+                  className="rounded-2xl border p-5"
+                  style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-sm font-bold" style={{ color: '#253122' }}>
+                          {booking.org}
+                        </p>
+                        <span
+                          className="rounded-md px-2 py-0.5 text-xs font-semibold"
+                          style={statusStyles[booking.status]}
+                        >
+                          {statusLabels[booking.status]}
+                        </span>
+                      </div>
+                      <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
+                        {booking.service} - {booking.member}
+                      </p>
+                      <div
+                        className="mt-2 flex items-center gap-3 text-xs"
+                        style={{ color: 'rgba(37,49,34,0.45)' }}
+                      >
+                        <span className="flex items-center gap-1">
+                          <CalendarDays size={11} />
+                          {booking.date}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Clock size={11} />
+                          {booking.time}
+                        </span>
+                        <span className="font-semibold" style={{ color: '#253122' }}>
+                          {booking.price} EUR
+                        </span>
+                      </div>
+                    </div>
+                    {booking.status !== 'CANCELLED' && (
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg p-1.5 transition-colors hover:bg-black/[.05]"
+                        style={{ color: 'rgba(37,49,34,0.3)' }}
+                        aria-label={`Annuler ${booking.service}`}
+                      >
+                        <X size={15} />
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/client-dashboard-overview.tsx
+++ b/components/dashboard/client-dashboard-overview.tsx
@@ -1,0 +1,199 @@
+import { CalendarDays, ChevronRight, Clock, Gift, Search, Sparkles } from 'lucide-react'
+import Link from 'next/link'
+
+const quickLinks = [
+  {
+    href: '/client/bookings',
+    label: 'Mes reservations',
+    sub: 'Voir et gerer vos rendez-vous a venir',
+    icon: CalendarDays,
+    accent: '#489B6E',
+  },
+  {
+    href: '/client/rewards',
+    label: 'Programme fidelite',
+    sub: 'Points, recompenses et avantages exclusifs',
+    icon: Gift,
+    accent: '#C5A56E',
+  },
+  {
+    href: '/search',
+    label: 'Trouver un professionnel',
+    sub: 'Explorer les salons disponibles pres de chez vous',
+    icon: Search,
+    accent: '#253122',
+  },
+] as const
+
+export function ClientDashboardOverview() {
+  return (
+    <div className="space-y-8">
+      <section aria-labelledby="next-rdv-heading">
+        <h2
+          id="next-rdv-heading"
+          className="mb-3 text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'rgba(37,49,34,0.4)' }}
+        >
+          Prochain rendez-vous
+        </h2>
+        <div
+          className="relative overflow-hidden rounded-2xl border p-6"
+          style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+        >
+          <div
+            className="absolute inset-y-0 left-0 w-1 rounded-l-2xl"
+            style={{ background: '#489B6E' }}
+          />
+          <div className="flex flex-wrap items-center gap-5 pl-4">
+            <div
+              className="flex size-11 shrink-0 items-center justify-center rounded-xl"
+              style={{ background: 'rgba(72,155,110,0.1)' }}
+            >
+              <CalendarDays size={20} style={{ color: '#489B6E' }} />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                Aucun rendez-vous a venir
+              </p>
+              <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                Reservez des maintenant chez votre salon prefere
+              </p>
+            </div>
+            <Link
+              id="client-book-next"
+              href="/search"
+              className="shrink-0 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-85"
+              style={{ background: '#489B6E' }}
+            >
+              Reserver
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-1">
+          <section aria-labelledby="stats-heading">
+            <h2
+              id="stats-heading"
+              className="mb-3 text-xs font-semibold tracking-widest uppercase"
+              style={{ color: 'rgba(37,49,34,0.4)' }}
+            >
+              Mon activite
+            </h2>
+            <div className="grid grid-cols-2 gap-4 lg:grid-cols-1">
+              <div
+                className="rounded-2xl border p-5"
+                style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+              >
+                <div className="flex items-center justify-between">
+                  <Clock size={16} style={{ color: 'rgba(37,49,34,0.35)' }} />
+                  <span
+                    className="rounded-full px-2 py-0.5 text-xs font-medium"
+                    style={{ background: 'rgba(37,49,34,0.06)', color: 'rgba(37,49,34,0.4)' }}
+                  >
+                    Total
+                  </span>
+                </div>
+                <p className="mt-4 text-4xl font-black" style={{ color: '#253122' }}>
+                  0
+                </p>
+                <p className="mt-1 text-xs font-medium" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  RDV realises
+                </p>
+              </div>
+
+              <div
+                className="rounded-2xl border p-5"
+                style={{
+                  borderColor: 'rgba(197,165,110,0.2)',
+                  background: 'rgba(197,165,110,0.05)',
+                }}
+              >
+                <div className="flex items-center justify-between">
+                  <Gift size={16} style={{ color: '#C5A56E' }} />
+                  <span
+                    className="rounded-full px-2 py-0.5 text-xs font-medium"
+                    style={{ background: 'rgba(197,165,110,0.12)', color: '#C5A56E' }}
+                  >
+                    Fidelite
+                  </span>
+                </div>
+                <p className="mt-4 text-4xl font-black" style={{ color: '#253122' }}>
+                  0
+                </p>
+                <p className="mt-1 text-xs font-medium" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  Points accumules
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <div
+            className="flex items-start gap-4 rounded-2xl border p-5"
+            style={{ borderColor: 'rgba(37,49,34,0.06)', background: 'rgba(37,49,34,0.02)' }}
+          >
+            <Sparkles size={18} style={{ color: '#C5A56E' }} className="mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                Bienvenue sur CutBook !
+              </p>
+              <p className="mt-1 text-xs leading-relaxed" style={{ color: 'rgba(37,49,34,0.5)' }}>
+                Reservez en 3 clics et cumulez des points fidelite a chaque visite.
+              </p>
+              <Link
+                href="/search"
+                className="mt-3 inline-flex text-xs font-semibold transition-opacity hover:opacity-75"
+                style={{ color: '#489B6E' }}
+              >
+                Explorer les salons
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <section className="lg:col-span-2" aria-labelledby="links-heading">
+          <h2
+            id="links-heading"
+            className="mb-3 text-xs font-semibold tracking-widest uppercase"
+            style={{ color: 'rgba(37,49,34,0.4)' }}
+          >
+            Acces rapide
+          </h2>
+          <div
+            className="divide-y overflow-hidden rounded-2xl border"
+            style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+          >
+            {quickLinks.map(({ href, label, sub, icon: Icon, accent }) => (
+              <Link
+                key={href}
+                href={href}
+                className="group flex items-center gap-4 px-6 py-5 transition-colors hover:bg-black/[.02]"
+              >
+                <div
+                  className="flex size-10 shrink-0 items-center justify-center rounded-xl"
+                  style={{ background: `${accent}12` }}
+                >
+                  <Icon size={18} style={{ color: accent }} />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                    {label}
+                  </p>
+                  <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                    {sub}
+                  </p>
+                </div>
+                <ChevronRight
+                  size={16}
+                  className="transition-transform group-hover:translate-x-0.5"
+                  style={{ color: 'rgba(37,49,34,0.2)' }}
+                />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/client-dashboard-overview.tsx
+++ b/components/dashboard/client-dashboard-overview.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import { CalendarDays, ChevronRight, Clock, Gift, Search, Sparkles } from 'lucide-react'
 import Link from 'next/link'
+import { trpc } from '@/lib/trpc/client'
 
 const quickLinks = [
   {
@@ -26,6 +29,11 @@ const quickLinks = [
 ] as const
 
 export function ClientDashboardOverview() {
+  const summary = trpc.clientPortal.dashboardSummary.useQuery()
+  const nextBooking = summary.data?.nextBooking ?? null
+  const completedBookingsCount = summary.data?.completedBookingsCount ?? 0
+  const loyaltyPoints = summary.data?.loyaltyPoints ?? 0
+
   return (
     <div className="space-y-8">
       <section aria-labelledby="next-rdv-heading">
@@ -52,12 +60,29 @@ export function ClientDashboardOverview() {
               <CalendarDays size={20} style={{ color: '#489B6E' }} />
             </div>
             <div className="flex-1">
-              <p className="text-sm font-semibold" style={{ color: '#253122' }}>
-                Aucun rendez-vous a venir
-              </p>
-              <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
-                Reservez des maintenant chez votre salon prefere
-              </p>
+              {summary.isLoading ? (
+                <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                  Chargement du prochain rendez-vous...
+                </p>
+              ) : nextBooking ? (
+                <>
+                  <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                    {nextBooking.service} chez {nextBooking.org}
+                  </p>
+                  <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                    {nextBooking.date} a {nextBooking.time} avec {nextBooking.member}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm font-semibold" style={{ color: '#253122' }}>
+                    Aucun rendez-vous a venir
+                  </p>
+                  <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                    Reservez des maintenant chez votre salon prefere
+                  </p>
+                </>
+              )}
             </div>
             <Link
               id="client-book-next"
@@ -96,7 +121,7 @@ export function ClientDashboardOverview() {
                   </span>
                 </div>
                 <p className="mt-4 text-4xl font-black" style={{ color: '#253122' }}>
-                  0
+                  {summary.isLoading ? '...' : completedBookingsCount}
                 </p>
                 <p className="mt-1 text-xs font-medium" style={{ color: 'rgba(37,49,34,0.45)' }}>
                   RDV realises
@@ -120,7 +145,7 @@ export function ClientDashboardOverview() {
                   </span>
                 </div>
                 <p className="mt-4 text-4xl font-black" style={{ color: '#253122' }}>
-                  0
+                  {summary.isLoading ? '...' : loyaltyPoints}
                 </p>
                 <p className="mt-1 text-xs font-medium" style={{ color: 'rgba(37,49,34,0.45)' }}>
                   Points accumules

--- a/components/dashboard/client-history-view.tsx
+++ b/components/dashboard/client-history-view.tsx
@@ -1,0 +1,141 @@
+import { CalendarDays, Clock } from 'lucide-react'
+
+type HistoryStatus = 'COMPLETED' | 'CANCELLED'
+
+interface ClientHistoryItem {
+  id: string
+  org: string
+  service: string
+  member: string
+  date: string
+  time: string
+  price: number
+  status: HistoryStatus
+}
+
+const statusStyles = {
+  COMPLETED: { background: 'rgba(72,155,110,0.1)', color: '#489B6E', label: 'Termine' },
+  CANCELLED: { background: 'rgba(37,49,34,0.06)', color: 'rgba(37,49,34,0.4)', label: 'Annule' },
+} satisfies Record<HistoryStatus, { background: string; color: string; label: string }>
+
+interface ClientHistoryViewProps {
+  history?: ClientHistoryItem[]
+}
+
+export function ClientHistoryView({ history = [] }: ClientHistoryViewProps) {
+  const completed = history.filter((booking) => booking.status === 'COMPLETED')
+  const totalSpent = completed.reduce((sum, booking) => sum + booking.price, 0)
+  const cancelledCount = history.filter((booking) => booking.status === 'CANCELLED').length
+
+  return (
+    <div className="w-full space-y-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+        <aside className="lg:col-span-1">
+          <div
+            className="rounded-2xl border p-5"
+            style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+          >
+            <p
+              className="mb-3 text-xs font-semibold tracking-widest uppercase"
+              style={{ color: 'rgba(37,49,34,0.4)' }}
+            >
+              Bilan
+            </p>
+            <div className="space-y-4">
+              <div>
+                <p className="text-3xl font-black" style={{ color: '#253122' }}>
+                  {completed.length}
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  RDV realises
+                </p>
+              </div>
+              <div className="border-t pt-4" style={{ borderColor: 'rgba(37,49,34,0.06)' }}>
+                <p className="text-3xl font-black" style={{ color: '#253122' }}>
+                  {totalSpent} EUR
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  Total depense
+                </p>
+              </div>
+              <div className="border-t pt-4" style={{ borderColor: 'rgba(37,49,34,0.06)' }}>
+                <p className="text-3xl font-black" style={{ color: '#253122' }}>
+                  {cancelledCount}
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                  Annules
+                </p>
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        <section className="lg:col-span-3" aria-label="Historique des reservations">
+          {history.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center rounded-2xl border p-16 text-center"
+              style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff', minHeight: '280px' }}
+            >
+              <CalendarDays size={40} className="mb-4" style={{ color: 'rgba(37,49,34,0.12)' }} />
+              <p className="font-semibold" style={{ color: '#253122' }}>
+                Aucun RDV passe
+              </p>
+              <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                Votre historique apparaitra ici apres votre premier rendez-vous.
+              </p>
+            </div>
+          ) : (
+            <ol className="space-y-3">
+              {history.map((booking) => {
+                const style = statusStyles[booking.status]
+
+                return (
+                  <li
+                    key={booking.id}
+                    className="rounded-2xl border p-5"
+                    style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-bold" style={{ color: '#253122' }}>
+                            {booking.org}
+                          </p>
+                          <span
+                            className="rounded-md px-2 py-0.5 text-xs font-semibold"
+                            style={{ background: style.background, color: style.color }}
+                          >
+                            {style.label}
+                          </span>
+                        </div>
+                        <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
+                          {booking.service} - {booking.member}
+                        </p>
+                        <div
+                          className="mt-2 flex items-center gap-3 text-xs"
+                          style={{ color: 'rgba(37,49,34,0.4)' }}
+                        >
+                          <span className="flex items-center gap-1">
+                            <CalendarDays size={11} />
+                            {booking.date}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Clock size={11} />
+                            {booking.time}
+                          </span>
+                          <span className="font-semibold" style={{ color: '#253122' }}>
+                            {booking.price} EUR
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                )
+              })}
+            </ol>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/client-history-view.tsx
+++ b/components/dashboard/client-history-view.tsx
@@ -1,6 +1,8 @@
-import { CalendarDays, Clock } from 'lucide-react'
+'use client'
 
-type HistoryStatus = 'COMPLETED' | 'CANCELLED'
+import { CalendarDays, Clock } from 'lucide-react'
+import type { BookingStatus } from '@/generated/prisma/enums'
+import { trpc } from '@/lib/trpc/client'
 
 interface ClientHistoryItem {
   id: string
@@ -10,19 +12,17 @@ interface ClientHistoryItem {
   date: string
   time: string
   price: number
-  status: HistoryStatus
+  status: BookingStatus
 }
 
 const statusStyles = {
+  PENDING: { background: 'rgba(197,165,110,0.12)', color: '#C5A56E', label: 'En attente' },
+  CONFIRMED: { background: 'rgba(72,155,110,0.12)', color: '#489B6E', label: 'Confirme' },
   COMPLETED: { background: 'rgba(72,155,110,0.1)', color: '#489B6E', label: 'Termine' },
   CANCELLED: { background: 'rgba(37,49,34,0.06)', color: 'rgba(37,49,34,0.4)', label: 'Annule' },
-} satisfies Record<HistoryStatus, { background: string; color: string; label: string }>
+} satisfies Record<BookingStatus, { background: string; color: string; label: string }>
 
-interface ClientHistoryViewProps {
-  history?: ClientHistoryItem[]
-}
-
-export function ClientHistoryView({ history = [] }: ClientHistoryViewProps) {
+function ClientHistoryContent({ history }: { history: ClientHistoryItem[] }) {
   const completed = history.filter((booking) => booking.status === 'COMPLETED')
   const totalSpent = completed.reduce((sum, booking) => sum + booking.price, 0)
   const cancelledCount = history.filter((booking) => booking.status === 'CANCELLED').length
@@ -138,4 +138,40 @@ export function ClientHistoryView({ history = [] }: ClientHistoryViewProps) {
       </div>
     </div>
   )
+}
+
+export function ClientHistoryView() {
+  const history = trpc.clientPortal.bookingHistory.useQuery()
+
+  if (history.isLoading) {
+    return (
+      <div
+        className="rounded-2xl border p-8 text-sm"
+        style={{
+          borderColor: 'rgba(37,49,34,0.08)',
+          background: '#fff',
+          color: 'rgba(37,49,34,0.55)',
+        }}
+      >
+        Chargement de l&apos;historique...
+      </div>
+    )
+  }
+
+  if (history.isError) {
+    return (
+      <div
+        className="rounded-2xl border p-8 text-sm"
+        style={{
+          borderColor: 'rgba(220,38,38,0.18)',
+          background: 'rgba(220,38,38,0.04)',
+          color: '#dc2626',
+        }}
+      >
+        Impossible de charger votre historique.
+      </div>
+    )
+  }
+
+  return <ClientHistoryContent history={history.data?.bookings ?? []} />
 }

--- a/components/dashboard/client-rewards-view.tsx
+++ b/components/dashboard/client-rewards-view.tsx
@@ -1,7 +1,29 @@
+'use client'
+
 import { ChevronRight, Gift } from 'lucide-react'
 import Link from 'next/link'
+import { trpc } from '@/lib/trpc/client'
 
 export function ClientRewardsView() {
+  const rewards = trpc.clientPortal.rewardsOverview.useQuery()
+  const loyaltyPoints = rewards.data?.loyaltyPoints ?? 0
+  const availableRewards = rewards.data?.availableRewards ?? []
+
+  if (rewards.isError) {
+    return (
+      <div
+        className="rounded-2xl border p-8 text-sm"
+        style={{
+          borderColor: 'rgba(220,38,38,0.18)',
+          background: 'rgba(220,38,38,0.04)',
+          color: '#dc2626',
+        }}
+      >
+        Impossible de charger vos recompenses.
+      </div>
+    )
+  }
+
   return (
     <div className="w-full space-y-6">
       <div
@@ -17,7 +39,7 @@ export function ClientRewardsView() {
           </div>
           <div>
             <p className="text-4xl font-black" style={{ color: '#253122' }}>
-              0
+              {rewards.isLoading ? '...' : loyaltyPoints}
             </p>
             <p className="text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
               Points disponibles
@@ -39,12 +61,28 @@ export function ClientRewardsView() {
           style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
         >
           <Gift size={36} className="mx-auto mb-4" style={{ color: 'rgba(37,49,34,0.12)' }} />
-          <p className="font-semibold" style={{ color: '#253122' }}>
-            Aucune recompense disponible
-          </p>
-          <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
-            Cumulez des points a chaque reservation pour debloquer des avantages.
-          </p>
+          {availableRewards.length === 0 ? (
+            <>
+              <p className="font-semibold" style={{ color: '#253122' }}>
+                Aucune recompense disponible
+              </p>
+              <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+                Cumulez des points a chaque reservation pour debloquer des avantages.
+              </p>
+            </>
+          ) : (
+            <ul className="space-y-2 text-left">
+              {availableRewards.map((reward) => (
+                <li
+                  key={reward.id}
+                  className="rounded-xl border px-4 py-3 text-sm"
+                  style={{ borderColor: 'rgba(37,49,34,0.08)', color: '#253122' }}
+                >
+                  {reward.type}
+                </li>
+              ))}
+            </ul>
+          )}
           <Link
             href="/search"
             className="mt-5 inline-flex items-center gap-1.5 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90"

--- a/components/dashboard/client-rewards-view.tsx
+++ b/components/dashboard/client-rewards-view.tsx
@@ -1,0 +1,60 @@
+import { ChevronRight, Gift } from 'lucide-react'
+import Link from 'next/link'
+
+export function ClientRewardsView() {
+  return (
+    <div className="w-full space-y-6">
+      <div
+        className="rounded-2xl border p-6"
+        style={{ borderColor: 'rgba(197,165,110,0.2)', background: 'rgba(197,165,110,0.05)' }}
+      >
+        <div className="flex items-center gap-4">
+          <div
+            className="flex size-12 shrink-0 items-center justify-center rounded-xl"
+            style={{ background: 'rgba(197,165,110,0.15)' }}
+          >
+            <Gift size={22} style={{ color: '#C5A56E' }} />
+          </div>
+          <div>
+            <p className="text-4xl font-black" style={{ color: '#253122' }}>
+              0
+            </p>
+            <p className="text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
+              Points disponibles
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <section aria-labelledby="rewards-heading">
+        <h2
+          id="rewards-heading"
+          className="mb-3 text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'rgba(37,49,34,0.4)' }}
+        >
+          Recompenses disponibles
+        </h2>
+        <div
+          className="rounded-2xl border p-10 text-center"
+          style={{ borderColor: 'rgba(37,49,34,0.08)', background: '#fff' }}
+        >
+          <Gift size={36} className="mx-auto mb-4" style={{ color: 'rgba(37,49,34,0.12)' }} />
+          <p className="font-semibold" style={{ color: '#253122' }}>
+            Aucune recompense disponible
+          </p>
+          <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.45)' }}>
+            Cumulez des points a chaque reservation pour debloquer des avantages.
+          </p>
+          <Link
+            href="/search"
+            className="mt-5 inline-flex items-center gap-1.5 rounded-xl px-5 py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-90"
+            style={{ background: '#489B6E' }}
+          >
+            Reserver maintenant
+            <ChevronRight size={14} />
+          </Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/components/dashboard/client-settings-view.tsx
+++ b/components/dashboard/client-settings-view.tsx
@@ -3,7 +3,6 @@
 import { useState, useTransition } from 'react'
 import {
   Mail,
-  Lock,
   Phone,
   Trash2,
   Save,
@@ -14,6 +13,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import { authClient } from '@/lib/auth/client'
+import { trpc } from '@/lib/trpc/client'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -138,7 +138,6 @@ function SubmitBtn({ pending, label = 'Enregistrer' }: { pending: boolean; label
 
 function EmailSection({ currentEmail }: { currentEmail: string }) {
   const [email, setEmail] = useState(currentEmail)
-  const [password, setPassword] = useState('')
   const [status, setStatus] = useState<Status>(null)
   const [pending, startTransition] = useTransition()
 
@@ -154,7 +153,6 @@ function EmailSection({ currentEmail }: { currentEmail: string }) {
         })
       } else {
         setStatus({ type: 'success', message: 'Un email de confirmation a été envoyé.' })
-        setPassword('')
       }
     })
   }
@@ -261,38 +259,59 @@ function PasswordSection() {
 
 // ── Phone section ──────────────────────────────────────────────────────────────
 
-function PhoneSection() {
-  const [phone, setPhone] = useState('')
+function PhoneForm({ initialPhone }: { initialPhone: string }) {
+  const utils = trpc.useUtils()
+  const [phone, setPhone] = useState(initialPhone)
   const [status, setStatus] = useState<Status>(null)
-  const [pending, startTransition] = useTransition()
+  const updatePhone = trpc.clientPortal.updatePhone.useMutation({
+    async onSuccess() {
+      await utils.clientPortal.profile.invalidate()
+      setStatus({ type: 'success', message: 'Numero enregistre.' })
+    },
+    onError(error) {
+      setStatus({ type: 'error', message: error.message })
+    },
+  })
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setStatus(null)
-    // TODO Samy S2 : tRPC user.updatePhone({ phone })
-    startTransition(async () => {
-      await new Promise((r) => setTimeout(r, 600)) // mock
-      setStatus({ type: 'success', message: 'Numéro enregistré (intégration tRPC en S2).' })
-    })
+    updatePhone.mutate({ phone })
   }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <Field
         id="settings-phone"
-        label="Numéro de téléphone"
+        label="Numero de telephone"
         type="tel"
         value={phone}
         onChange={setPhone}
         placeholder="+33 6 12 34 56 78"
+        disabled={updatePhone.isPending}
         suffix={<Phone size={14} style={{ color: 'rgba(37,49,34,0.3)' }} />}
       />
       <Toast status={status} />
-      <SubmitBtn pending={pending} />
+      <SubmitBtn pending={updatePhone.isPending} />
     </form>
   )
 }
 
+function PhoneSection() {
+  const profile = trpc.clientPortal.profile.useQuery()
+
+  if (profile.isLoading) {
+    return <p className="text-muted-foreground text-sm">Chargement du telephone...</p>
+  }
+
+  if (profile.isError) {
+    return <p className="text-destructive text-sm">Impossible de charger le telephone.</p>
+  }
+
+  const initialPhone = profile.data?.phone ?? ''
+
+  return <PhoneForm key={initialPhone} initialPhone={initialPhone} />
+}
 // ── Delete account section ─────────────────────────────────────────────────────
 
 function DeleteSection() {
@@ -389,7 +408,7 @@ interface SettingsClientProps {
   currentEmail: string
 }
 
-export function SettingsClient({ currentEmail }: SettingsClientProps) {
+export function ClientSettingsView({ currentEmail }: SettingsClientProps) {
   return (
     <div className="w-full max-w-2xl space-y-6">
       <div>

--- a/components/dashboard/client-sidebar.tsx
+++ b/components/dashboard/client-sidebar.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { CalendarDays, Gift, History, Home, LogOut, Scissors, Settings } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { signOut } from '@/lib/auth/client'
+
+const navItems = [
+  { href: '/client', label: 'Accueil', icon: Home, exact: true },
+  { href: '/client/bookings', label: 'Mes RDV', icon: CalendarDays, exact: false },
+  { href: '/client/history', label: 'Historique', icon: History, exact: false },
+  { href: '/client/rewards', label: 'Fidélité', icon: Gift, exact: false },
+  { href: '/client/settings', label: 'Paramètres', icon: Settings, exact: false },
+] as const
+
+export function ClientSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside
+      className="flex w-60 shrink-0 flex-col"
+      style={{ background: '#253122' }}
+      aria-label="Navigation client"
+    >
+      {/* Brand */}
+      <div
+        className="flex h-16 items-center gap-2.5 border-b px-5"
+        style={{ borderColor: 'rgba(255,255,255,0.08)' }}
+      >
+        <div
+          className="flex size-7 items-center justify-center rounded-lg"
+          style={{ background: '#489B6E' }}
+        >
+          <Scissors size={13} className="rotate-90 text-white" />
+        </div>
+        <span className="text-base font-bold tracking-tight text-white">CutBook</span>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex flex-1 flex-col gap-0.5 p-3" aria-label="Navigation client">
+        <p
+          className="mb-2 px-3 text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'rgba(255,255,255,0.3)' }}
+        >
+          Menu
+        </p>
+        {navItems.map((item) => {
+          const Icon = item.icon
+          const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href)
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
+                isActive ? 'text-white' : 'text-white/50 hover:text-white/80',
+              )}
+              style={isActive ? { background: 'rgba(72,155,110,0.2)' } : {}}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <Icon size={16} style={{ color: isActive ? '#489B6E' : undefined }} />
+              {item.label}
+              {isActive && (
+                <span className="ml-auto size-1.5 rounded-full" style={{ background: '#489B6E' }} />
+              )}
+            </Link>
+          )
+        })}
+      </nav>
+
+      {/* Logout */}
+      <div className="border-t p-3" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
+        <button
+          id="client-sidebar-logout"
+          type="button"
+          onClick={async () => {
+            await signOut()
+            window.location.href = '/login'
+          }}
+          className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all"
+          style={{ color: 'rgba(255,255,255,0.4)' }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.7)')}
+          onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.4)')}
+        >
+          <LogOut size={16} />
+          Se déconnecter
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/components/dashboard/dashboard-breadcrumb.tsx
+++ b/components/dashboard/dashboard-breadcrumb.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ChevronRight } from 'lucide-react'
+
+const ROOT_LABELS = {
+  client: 'Accueil',
+  member: 'Tableau de bord',
+} as const
+
+const ROUTE_LABELS: Record<string, string> = {
+  '/client': 'Accueil',
+  '/client/bookings': 'Mes réservations',
+  '/client/history': 'Historique',
+  '/client/rewards': 'Fidélité',
+  '/client/settings': 'Paramètres',
+  '/member': 'Tableau de bord',
+  '/member/calendar': 'Mon calendrier',
+  '/member/availability': 'Mes créneaux',
+  '/member/profile': 'Mon profil',
+}
+
+interface DashboardBreadcrumbProps {
+  base: keyof typeof ROOT_LABELS
+}
+
+function humanizeSegment(segment: string) {
+  return decodeURIComponent(segment)
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+export function DashboardBreadcrumb({ base }: DashboardBreadcrumbProps) {
+  const pathname = usePathname()
+  const baseHref = `/${base}`
+  const segments = pathname
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter(Boolean)
+
+  if (segments[0] !== base) {
+    return null
+  }
+
+  const items = [
+    { href: baseHref, label: ROOT_LABELS[base] },
+    ...segments.slice(1).map((segment, index) => {
+      const href = `/${segments.slice(0, index + 2).join('/')}`
+      return {
+        href,
+        label: ROUTE_LABELS[href] ?? humanizeSegment(segment),
+      }
+    }),
+  ]
+
+  return (
+    <nav aria-label="Fil d'ariane" className="mb-6 flex items-center gap-2 text-sm">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1
+
+        return (
+          <div key={item.href} className="flex items-center gap-2">
+            {index > 0 && <ChevronRight size={14} style={{ color: 'rgba(37,49,34,0.22)' }} />}
+            {isLast ? (
+              <span className="font-semibold" style={{ color: '#253122' }}>
+                {item.label}
+              </span>
+            ) : (
+              <Link
+                href={item.href}
+                className="transition-opacity hover:opacity-70"
+                style={{ color: 'rgba(37,49,34,0.5)' }}
+              >
+                {item.label}
+              </Link>
+            )}
+          </div>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/dashboard/logout-button.tsx
+++ b/components/dashboard/logout-button.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { LogOut } from 'lucide-react'
+import { signOut } from '@/lib/auth/client'
+
+export function LogoutButton() {
+  return (
+    <button
+      id="client-logout"
+      type="button"
+      onClick={async () => {
+        await signOut()
+        window.location.href = '/login'
+      }}
+      className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:bg-black/[.05]"
+      style={{ color: 'rgba(37,49,34,0.5)' }}
+    >
+      <LogOut size={15} />
+      Déconnexion
+    </button>
+  )
+}

--- a/components/dashboard/member-dashboard-overview.tsx
+++ b/components/dashboard/member-dashboard-overview.tsx
@@ -1,0 +1,63 @@
+import { CalendarDays, Clock, Users } from 'lucide-react'
+import Link from 'next/link'
+import { StatCard } from '@/components/dashboard/stat-card'
+import { Button } from '@/components/ui/button'
+
+export function MemberDashboardOverview() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-8">
+      <section aria-labelledby="member-stats-heading">
+        <h2
+          id="member-stats-heading"
+          className="text-muted-foreground mb-4 text-sm font-medium tracking-wider uppercase"
+        >
+          Aujourd&apos;hui
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatCard
+            title="RDV aujourd'hui"
+            value="0"
+            description="Aucun RDV ce jour"
+            icon={CalendarDays}
+          />
+          <StatCard
+            title="RDV cette semaine"
+            value="0"
+            description="Total de la semaine"
+            icon={Clock}
+          />
+          <StatCard title="Clients ce mois" value="0" description="Clients uniques" icon={Users} />
+        </div>
+      </section>
+
+      <section aria-labelledby="member-actions-heading">
+        <h2
+          id="member-actions-heading"
+          className="text-muted-foreground mb-4 text-sm font-medium tracking-wider uppercase"
+        >
+          Actions rapides
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="bg-card space-y-3 rounded-xl border p-6">
+            <h3 className="font-semibold">Mon calendrier</h3>
+            <p className="text-muted-foreground text-sm">
+              Visualisez tous vos RDV en vue semaine ou mois.
+            </p>
+            <Button id="member-view-calendar" size="sm" asChild>
+              <Link href="/member/calendar">Ouvrir le calendrier</Link>
+            </Button>
+          </div>
+          <div className="bg-card space-y-3 rounded-xl border p-6">
+            <h3 className="font-semibold">Mes disponibilites</h3>
+            <p className="text-muted-foreground text-sm">
+              Gerez vos creneaux pour que les clients puissent reserver.
+            </p>
+            <Button id="member-manage-slots" size="sm" variant="outline" asChild>
+              <Link href="/member/availability">Gerer les creneaux</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/components/dashboard/member-placeholder-view.tsx
+++ b/components/dashboard/member-placeholder-view.tsx
@@ -1,0 +1,26 @@
+import type { LucideIcon } from 'lucide-react'
+
+interface MemberPlaceholderViewProps {
+  title: string
+  icon: LucideIcon
+  headline: string
+  description: string
+}
+
+export function MemberPlaceholderView({
+  title,
+  icon: Icon,
+  headline,
+  description,
+}: MemberPlaceholderViewProps) {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <div className="bg-card flex min-h-[400px] flex-col items-center justify-center rounded-xl border p-10 text-center">
+        <Icon size={40} className="text-muted-foreground/30 mb-4" />
+        <p className="font-semibold">{headline}</p>
+        <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/member-sidebar.tsx
+++ b/components/dashboard/member-sidebar.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { LayoutDashboard, CalendarDays, Clock, User, LogOut, Scissors } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { signOut } from '@/lib/auth/client'
+
+const navItems = [
+  { href: '/member', label: 'Tableau de bord', icon: LayoutDashboard, exact: true },
+  { href: '/member/calendar', label: 'Mon calendrier', icon: CalendarDays, exact: false },
+  { href: '/member/availability', label: 'Mes créneaux', icon: Clock, exact: false },
+  { href: '/member/profile', label: 'Mon profil', icon: User, exact: false },
+] as const
+
+export function MemberSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside
+      className="flex w-64 shrink-0 flex-col"
+      style={{ background: '#253122' }}
+      aria-label="Navigation professionnel"
+    >
+      {/* Brand */}
+      <div
+        className="flex h-16 items-center gap-2.5 border-b px-5"
+        style={{ borderColor: 'rgba(255,255,255,0.08)' }}
+      >
+        <div
+          className="flex size-7 items-center justify-center rounded-lg"
+          style={{ background: '#489B6E' }}
+        >
+          <Scissors size={13} className="rotate-90 text-white" />
+        </div>
+        <span className="text-base font-bold tracking-tight text-white">CutBook</span>
+        <span
+          className="ml-auto rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+          style={{ background: 'rgba(72,155,110,0.25)', color: '#489B6E' }}
+        >
+          Pro
+        </span>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex flex-1 flex-col gap-0.5 p-3" aria-label="Navigation professionnel">
+        <p
+          className="mb-2 px-3 text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'rgba(255,255,255,0.3)' }}
+        >
+          Menu
+        </p>
+        {navItems.map((item) => {
+          const Icon = item.icon
+          const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href)
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
+                isActive ? 'text-white' : 'text-white/50 hover:text-white/80',
+              )}
+              style={isActive ? { background: 'rgba(72,155,110,0.2)' } : {}}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <Icon size={16} style={{ color: isActive ? '#489B6E' : undefined }} />
+              {item.label}
+              {isActive && (
+                <span className="ml-auto size-1.5 rounded-full" style={{ background: '#489B6E' }} />
+              )}
+            </Link>
+          )
+        })}
+      </nav>
+
+      {/* Logout */}
+      <div className="border-t p-3" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
+        <button
+          id="member-sidebar-logout"
+          type="button"
+          onClick={async () => {
+            await signOut()
+            window.location.href = '/login'
+          }}
+          className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all"
+          style={{ color: 'rgba(255,255,255,0.4)' }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.7)')}
+          onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.4)')}
+        >
+          <LogOut size={16} />
+          Se déconnecter
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/components/dashboard/stat-card.tsx
+++ b/components/dashboard/stat-card.tsx
@@ -1,0 +1,50 @@
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface StatCardProps {
+  title: string
+  value: string | number
+  description?: string
+  icon: LucideIcon
+  trend?: {
+    value: string
+    positive: boolean
+  }
+  className?: string
+}
+
+export function StatCard({
+  title,
+  value,
+  description,
+  icon: Icon,
+  trend,
+  className,
+}: StatCardProps) {
+  return (
+    <div className={cn('bg-card flex flex-col gap-3 rounded-xl border p-6 shadow-sm', className)}>
+      <div className="flex items-start justify-between">
+        <p className="text-muted-foreground text-sm font-medium">{title}</p>
+        <div className="bg-primary/10 flex size-9 items-center justify-center rounded-lg">
+          <Icon className="text-primary size-5" />
+        </div>
+      </div>
+
+      <div>
+        <p className="text-foreground text-2xl font-bold">{value}</p>
+        {description && <p className="text-muted-foreground mt-1 text-sm">{description}</p>}
+      </div>
+
+      {trend && (
+        <p
+          className={cn(
+            'text-xs font-medium',
+            trend.positive ? 'text-primary' : 'text-destructive',
+          )}
+        >
+          {trend.positive ? '↑' : '↓'} {trend.value}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/lib/client/_format.ts
+++ b/lib/client/_format.ts
@@ -1,0 +1,59 @@
+import type { BookingStatus, RewardStatus } from '@/generated/prisma/enums'
+
+export interface ClientBookingItem {
+  id: string
+  org: string
+  service: string
+  member: string
+  date: string
+  time: string
+  price: number
+  status: BookingStatus
+}
+
+export interface ClientRewardItem {
+  id: string
+  type: string
+  status: RewardStatus
+  expirationDate: string
+}
+
+type BookingWithDetails = {
+  id: string
+  status: BookingStatus
+  totalPrice: number
+  service: {
+    name: string
+  }
+  member: {
+    user: {
+      name: string
+    }
+    organization: {
+      name: string
+    }
+  }
+  timeSlot: {
+    date: Date
+    startTime: string
+  }
+}
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' })
+
+export function toClientBookingItem(booking: BookingWithDetails): ClientBookingItem {
+  return {
+    id: booking.id,
+    org: booking.member.organization.name,
+    service: booking.service.name,
+    member: booking.member.user.name,
+    date: dateFormatter.format(booking.timeSlot.date),
+    time: booking.timeSlot.startTime,
+    price: booking.totalPrice,
+    status: booking.status,
+  }
+}
+
+export function toDateOnly(value = new Date()) {
+  return new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()))
+}

--- a/lib/client/bookings.ts
+++ b/lib/client/bookings.ts
@@ -1,0 +1,81 @@
+import { BookingStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { toClientBookingItem, toDateOnly } from './_format'
+
+const bookingInclude = {
+  service: {
+    select: {
+      name: true,
+    },
+  },
+  member: {
+    select: {
+      user: {
+        select: {
+          name: true,
+        },
+      },
+      organization: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  },
+  timeSlot: {
+    select: {
+      date: true,
+      startTime: true,
+    },
+  },
+} as const
+
+export async function getClientUpcomingBookings(clientId: string) {
+  const today = toDateOnly()
+  const bookings = await db.booking.findMany({
+    where: {
+      clientId,
+      status: { in: [BookingStatus.PENDING, BookingStatus.CONFIRMED] },
+      timeSlot: {
+        date: { gte: today },
+      },
+    },
+    include: bookingInclude,
+    orderBy: [{ timeSlot: { date: 'asc' } }, { timeSlot: { startTime: 'asc' } }],
+  })
+
+  return bookings.map(toClientBookingItem)
+}
+
+export async function getClientBookingHistory(clientId: string) {
+  const today = toDateOnly()
+  const bookings = await db.booking.findMany({
+    where: {
+      clientId,
+      OR: [
+        { status: { in: [BookingStatus.COMPLETED, BookingStatus.CANCELLED] } },
+        { timeSlot: { date: { lt: today } } },
+      ],
+    },
+    include: bookingInclude,
+    orderBy: [{ timeSlot: { date: 'desc' } }, { timeSlot: { startTime: 'desc' } }],
+  })
+
+  const items = bookings.map(toClientBookingItem)
+  const completedCount = items.filter(
+    (booking) => booking.status === BookingStatus.COMPLETED,
+  ).length
+  const cancelledCount = items.filter(
+    (booking) => booking.status === BookingStatus.CANCELLED,
+  ).length
+  const totalSpent = items
+    .filter((booking) => booking.status === BookingStatus.COMPLETED)
+    .reduce((sum, booking) => sum + booking.price, 0)
+
+  return {
+    bookings: items,
+    completedCount,
+    cancelledCount,
+    totalSpent,
+  }
+}

--- a/lib/client/dashboard.ts
+++ b/lib/client/dashboard.ts
@@ -1,0 +1,61 @@
+import { BookingStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { toClientBookingItem, toDateOnly } from './_format'
+import { getClientRewardsOverview } from './rewards'
+
+export async function getClientDashboardSummary(clientId: string) {
+  const today = toDateOnly()
+
+  const [nextBooking, completedBookingsCount, rewardsOverview] = await Promise.all([
+    db.booking.findFirst({
+      where: {
+        clientId,
+        status: { in: [BookingStatus.PENDING, BookingStatus.CONFIRMED] },
+        timeSlot: {
+          date: { gte: today },
+        },
+      },
+      include: {
+        service: {
+          select: {
+            name: true,
+          },
+        },
+        member: {
+          select: {
+            user: {
+              select: {
+                name: true,
+              },
+            },
+            organization: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+        timeSlot: {
+          select: {
+            date: true,
+            startTime: true,
+          },
+        },
+      },
+      orderBy: [{ timeSlot: { date: 'asc' } }, { timeSlot: { startTime: 'asc' } }],
+    }),
+    db.booking.count({
+      where: {
+        clientId,
+        status: BookingStatus.COMPLETED,
+      },
+    }),
+    getClientRewardsOverview(clientId),
+  ])
+
+  return {
+    nextBooking: nextBooking ? toClientBookingItem(nextBooking) : null,
+    completedBookingsCount,
+    loyaltyPoints: rewardsOverview.loyaltyPoints,
+  }
+}

--- a/lib/client/profile.ts
+++ b/lib/client/profile.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { db } from '@/lib/db'
+
+export const updateClientPhoneSchema = z.object({
+  phone: z.string().trim().max(32).nullable(),
+})
+
+export async function getClientProfile(clientId: string) {
+  return await db.user.findUniqueOrThrow({
+    where: { id: clientId },
+    select: {
+      name: true,
+      email: true,
+      phone: true,
+      loyaltyPoints: true,
+    },
+  })
+}
+
+export async function updateClientPhone(
+  clientId: string,
+  input: z.infer<typeof updateClientPhoneSchema>,
+) {
+  const phone = input.phone?.trim() || null
+
+  return await db.user.update({
+    where: { id: clientId },
+    data: { phone },
+    select: {
+      name: true,
+      email: true,
+      phone: true,
+      loyaltyPoints: true,
+    },
+  })
+}

--- a/lib/client/rewards.ts
+++ b/lib/client/rewards.ts
@@ -1,0 +1,33 @@
+import { RewardStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+
+export async function getClientRewardsOverview(clientId: string) {
+  const user = await db.user.findUnique({
+    where: { id: clientId },
+    select: {
+      loyaltyPoints: true,
+    },
+  })
+
+  const rewards = await db.reward.findMany({
+    where: {
+      clientId,
+      status: RewardStatus.AVAILABLE,
+    },
+    select: {
+      id: true,
+      type: true,
+      status: true,
+      expirationDate: true,
+    },
+    orderBy: { expirationDate: 'asc' },
+  })
+
+  return {
+    loyaltyPoints: user?.loyaltyPoints ?? 0,
+    availableRewards: rewards.map((reward) => ({
+      ...reward,
+      expirationDate: reward.expirationDate.toISOString(),
+    })),
+  }
+}

--- a/lib/organizations/public-organization.integration.test.ts
+++ b/lib/organizations/public-organization.integration.test.ts
@@ -83,6 +83,16 @@ describe('public organization data', () => {
     )
   })
 
+  it('filtre les creneaux par membre selectionne', async () => {
+    const slots = await listPublicOrganizationAvailableSlots(seedOrganization.slug, {
+      memberId: seedMembers.mila.id,
+    })
+
+    expect(slots).not.toHaveLength(0)
+    expect(slots.every((slot) => slot.memberId === seedMembers.mila.id)).toBe(true)
+    expect(slots.map((slot) => slot.id)).not.toContain('seed-slot-leo-2')
+  })
+
   it('retourne une liste vide pour les creneaux d une organisation inconnue', async () => {
     await expect(listPublicOrganizationAvailableSlots('orga-inconnue')).resolves.toEqual([])
   })

--- a/lib/organizations/public-organization.ts
+++ b/lib/organizations/public-organization.ts
@@ -42,12 +42,20 @@ export async function getPublicOrganizationBySlug(orgSlug: string) {
   })
 }
 
-export async function listPublicOrganizationAvailableSlots(orgSlug: string) {
+interface PublicOrganizationSlotFilters {
+  memberId?: string
+}
+
+export async function listPublicOrganizationAvailableSlots(
+  orgSlug: string,
+  filters: PublicOrganizationSlotFilters = {},
+) {
   const slug = normalizePublicOrgSlug(orgSlug)
 
   return await db.timeSlot.findMany({
     where: {
       member: {
+        ...(filters.memberId ? { id: filters.memberId } : {}),
         organization: {
           slug,
         },

--- a/lib/trpc/routers/client.ts
+++ b/lib/trpc/routers/client.ts
@@ -1,0 +1,33 @@
+import { router, protectedProcedure } from '../init'
+import { getClientBookingHistory, getClientUpcomingBookings } from '@/lib/client/bookings'
+import { getClientDashboardSummary } from '@/lib/client/dashboard'
+import { getClientProfile, updateClientPhone, updateClientPhoneSchema } from '@/lib/client/profile'
+import { getClientRewardsOverview } from '@/lib/client/rewards'
+
+export const clientRouter = router({
+  dashboardSummary: protectedProcedure.query(async ({ ctx }) => {
+    return await getClientDashboardSummary(ctx.user.id)
+  }),
+
+  upcomingBookings: protectedProcedure.query(async ({ ctx }) => {
+    return await getClientUpcomingBookings(ctx.user.id)
+  }),
+
+  bookingHistory: protectedProcedure.query(async ({ ctx }) => {
+    return await getClientBookingHistory(ctx.user.id)
+  }),
+
+  rewardsOverview: protectedProcedure.query(async ({ ctx }) => {
+    return await getClientRewardsOverview(ctx.user.id)
+  }),
+
+  profile: protectedProcedure.query(async ({ ctx }) => {
+    return await getClientProfile(ctx.user.id)
+  }),
+
+  updatePhone: protectedProcedure
+    .input(updateClientPhoneSchema)
+    .mutation(async ({ ctx, input }) => {
+      return await updateClientPhone(ctx.user.id, input)
+    }),
+})

--- a/lib/trpc/routers/index.ts
+++ b/lib/trpc/routers/index.ts
@@ -2,11 +2,13 @@
 // Ajouter ici les nouveaux routers (booking, service, member, review, reward).
 import { router } from '../init'
 import { bookingRouter } from './booking'
+import { clientRouter } from './client'
 import { organizationRouter } from './organization'
 
 export const appRouter = router({
   organization: organizationRouter,
   booking: bookingRouter,
+  clientPortal: clientRouter,
   // service: serviceRouter,    // TODO
   // member: memberRouter,      // TODO
   // review: reviewRouter,      // TODO


### PR DESCRIPTION
## Resume
- Rebase logique du dashboard client depuis `dev`, sans reprendre l'ancienne branche distante divergente.
- Ajout des pages protegees client avec sidebar, fil d'Ariane dynamique et vues dediees.
- Premiere connexion du front client a tRPC pour remplacer les donnees hardcodees progressivement.

## Changements
- Ajoute les routes client protegees : `/client`, `/client/bookings`, `/client/history`, `/client/rewards`, `/client/settings`.
- Ajoute les layouts/sidebar client et member sous `app/(protected)`.
- Ajoute les composants dashboard client : overview, bookings, history, rewards, settings.
- Ajoute le breadcrumb dashboard reutilisable dans les layouts.
- Ajoute les services `lib/client/*` pour formatter et recuperer les donnees client depuis Prisma.
- Ajoute le router tRPC `clientPortal` avec dashboard summary, bookings, history, rewards, profile et update phone.
- Convertit les vues client data-driven en petits Client Components utilisant tRPC/TanStack Query.
- Corrige le choix de creneau public pour ne proposer que les slots du membre selectionne.
- Ajoute une couverture integration sur le filtrage des slots par membre.

## Points d'attention
- Le router est nomme `clientPortal` pour eviter une collision avec les helpers internes tRPC cote React.
- Les pages restent majoritairement Server Components ; seules les zones qui affichent ou mutent de la data utilisent `use client`.
- La partie member est presente cote UI/layout, mais le raccordement tRPC member sera traite dans une branche separee.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:integration`
- `pnpm build:check`