### PR TITLE
refactor: auth server barrel

### DIFF
--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,21 +1,4 @@
-// Barrel SERVER pour l'auth.
+// Barrel SERVER public pour l'auth.
 // A importer dans : layouts, pages (RSC), Server Actions, route handlers, middleware tRPC.
-// PAS dans des composants client → utiliser `@/lib/auth/client`.
-import { headers } from 'next/headers'
-import { authConfig } from './_config'
-
-export const auth = authConfig
-
-/**
- * Recupere la session de l'utilisateur cote serveur.
- * Retourne `null` si pas connecte.
- *
- * Usage :
- *   const session = await getSession()
- *   if (!session) redirect('/login')
- */
-export async function getSession() {
-  return await auth.api.getSession({
-    headers: await headers(),
-  })
-}
+// PAS dans des composants client -> utiliser `@/lib/auth/client`.
+export { auth, getSession } from './server'

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,0 +1,21 @@
+// Auth SERVER.
+// A importer directement seulement si tu veux expliciter le runtime serveur.
+// L'import public recommande reste `@/lib/auth`.
+import { headers } from 'next/headers'
+import { authConfig } from './_config'
+
+export const auth = authConfig
+
+/**
+ * Recupere la session de l'utilisateur cote serveur.
+ * Retourne `null` si pas connecte.
+ *
+ * Usage :
+ *   const session = await getSession()
+ *   if (!session) redirect('/login')
+ */
+export async function getSession() {
+  return await auth.api.getSession({
+    headers: await headers(),
+  })
+}


### PR DESCRIPTION
## Resume
- Extrait la logique serveur auth dans `lib/auth/server.ts`.
- Garde `@/lib/auth` comme barrel serveur public.
- Ne change pas le comportement runtime de BetterAuth.

## Changements
- Ajout de `lib/auth/server.ts` avec `auth` et `getSession()`.
- Simplification de `lib/auth/index.ts` en re-export public.

## Commits
- `b743453 refactor: auth server barrel`

## Points d'attention
- Aucun breaking change attendu : les imports existants `@/lib/auth` restent valides.

## Tests
- `pnpm exec tsc --noEmit --pretty false` - OK local
- Pre-push: `pnpm typecheck` - OK
- Pre-push: `pnpm lint` - OK
- Pre-push: `pnpm test` - 8 fichiers, 15 tests OK
- Pre-push: `pnpm test:integration` - 5 fichiers, 20 tests OK
- Pre-push: `pnpm build:check` - OK