### PR TITLE
ci: isolate test db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,20 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: cutbook
+          POSTGRES_PASSWORD: cutbook
+          POSTGRES_DB: cutbook_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U cutbook -d cutbook_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Checkout
@@ -58,12 +72,12 @@ jobs:
 
       - name: Integration tests
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          POSTGRES_USER: cutbook
+          POSTGRES_PASSWORD: cutbook
+          POSTGRES_DB: cutbook_test
         run: |
-          if [ -z "$DATABASE_URL" ]; then
-            echo "DATABASE_URL secret missing; skipping integration tests."
-            exit 0
-          fi
+          export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB"
+          pnpm prisma db push
           pnpm test:integration
 
       - name: Build


### PR DESCRIPTION
## Resume
- Ajoute un Postgres jetable dans le job GitHub Actions.
- Remplace le secret `DATABASE_URL` par une DB locale au job CI.
- Cree le schema avec `pnpm prisma db push` avant les tests d'integration.

## Changements
- Ajout du service `postgres:16-alpine` dans `.github/workflows/ci.yml`.
- Construction de `DATABASE_URL` au runtime pour eviter les collisions entre PRs.
- Suppression du skip des tests d'integration quand le secret manque.

## Commits
- `af4f491 ci: isolate test db`

## Points d'attention
- Apres merge, le secret GitHub `DATABASE_URL` n'est plus requis pour la CI.
- Chaque run seed une DB fraiche et isolee.

## Tests
- `pnpm exec tsc --noEmit --pretty false` - OK local
- `pnpm secretlint .github/workflows/ci.yml` - OK local
- Pre-push: `pnpm typecheck` - OK
- Pre-push: `pnpm lint` - OK
- Pre-push: `pnpm test` - 8 fichiers, 15 tests OK
- Pre-push: `pnpm test:integration` - 5 fichiers, 20 tests OK
- Pre-push: `pnpm build:check` - OK