### PR TITLE
feat: require email verify

### DIFF
--- a/components/auth/login-form.test.tsx
+++ b/components/auth/login-form.test.tsx
@@ -55,4 +55,22 @@ describe('LoginForm', () => {
       value: originalLocation,
     })
   })
+
+  it("affiche un message quand l'email n'est pas verifie", async () => {
+    const user = userEvent.setup()
+
+    authMocks.signInEmail.mockImplementation(async ({ fetchOptions }) => {
+      fetchOptions.onResponse({ response: { status: 403 } })
+    })
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText('Adresse email'), 'client@example.com')
+    await user.type(screen.getByLabelText('Mot de passe'), 'password-123')
+    await user.click(screen.getByRole('button', { name: 'Se connecter' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Vérifie ton email avant de te connecter.',
+    )
+  })
 })

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -59,6 +59,10 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
             setServerError('Trop de tentatives. Réessaie dans quelques secondes.')
             setIsLoading(false)
           }
+          if (ctx.response.status === 403) {
+            setServerError('Vérifie ton email avant de te connecter.')
+            setIsLoading(false)
+          }
         },
         onSuccess: () => {
           // Cookie garanti écrit — redirect safe

--- a/lib/auth/_config.ts
+++ b/lib/auth/_config.ts
@@ -4,6 +4,7 @@
 import { betterAuth } from 'better-auth'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
 import { db } from '@/lib/db'
+import { sendEmail, VerifyEmailTemplate } from '@/lib/email'
 import { env, getServerAppUrl } from '@/lib/env'
 
 export const authConfig = betterAuth({
@@ -14,9 +15,30 @@ export const authConfig = betterAuth({
   // Auth email + password
   emailAndPassword: {
     enabled: true,
-    requireEmailVerification: false, // a activer en prod
+    requireEmailVerification: true,
     minPasswordLength: 8,
     maxPasswordLength: 128,
+  },
+
+  emailVerification: {
+    sendOnSignUp: true,
+    sendOnSignIn: true,
+    autoSignInAfterVerification: true,
+    expiresIn: 60 * 60,
+    sendVerificationEmail: async ({ user, url }) => {
+      await sendEmail({
+        to: user.email,
+        subject: 'Confirme ton email CutBook',
+        react: VerifyEmailTemplate({ name: user.name, verificationUrl: url }),
+        text: `Confirme ton adresse email CutBook : ${url}`,
+        tags: [
+          {
+            name: 'type',
+            value: 'email-verification',
+          },
+        ],
+      })
+    },
   },
 
   // Auth Google OAuth


### PR DESCRIPTION
## Resume
- Active la verification email obligatoire pour le login email/password.
- Branche BetterAuth sur le template `VerifyEmailTemplate` via `sendEmail()`.
- Ajoute un message clair quand un utilisateur tente de se connecter sans email verifie.

## Changements
- `requireEmailVerification` passe a `true` dans la config BetterAuth.
- Ajout de `emailVerification.sendVerificationEmail` avec envoi via le provider email configure.
- Envoi automatique au signup et au signin si l'email n'est pas verifie.
- Ajout d'un test UI pour le status `403` au login.

## Commits
- `899a6c9 feat: require email verify`

## Points d'attention
- PR stackee sur `feat/resend-email-setup`, car elle depend de `lib/email`.
- En local, utiliser `EMAIL_PROVIDER=smtp` + Mailpit pour voir les emails.
- En prod, utiliser `EMAIL_PROVIDER=resend` avec un domaine Resend verifie.

## Tests
- `pnpm exec tsc --noEmit --pretty false` - OK local
- `pnpm exec vitest run components/auth/login-form.test.tsx --passWithNoTests` - OK local
- Pre-push: `pnpm typecheck` - OK
- Pre-push: `pnpm lint` - OK
- Pre-push: `pnpm test` - 8 fichiers, 16 tests OK
- Pre-push: `pnpm test:integration` - 5 fichiers, 20 tests OK
- Pre-push: `pnpm build:check` - OK