### PR TITLE
feat: add auth proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const protectedRoutes = ['/client', '/member']
+const authRoutes = ['/login', '/register']
+
+function isRoute(pathname: string, routes: string[]) {
+  return routes.some((route) => pathname === route || pathname.startsWith(`${route}/`))
+}
+
+function hasSessionCookie(request: NextRequest) {
+  return Boolean(
+    request.cookies.get('better-auth.session_token')?.value ||
+    request.cookies.get('__Secure-better-auth.session_token')?.value,
+  )
+}
+
+function redirectToLogin(request: NextRequest) {
+  const loginUrl = new URL('/login', request.url)
+  loginUrl.searchParams.set('callbackUrl', `${request.nextUrl.pathname}${request.nextUrl.search}`)
+
+  return NextResponse.redirect(loginUrl)
+}
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const isAuthenticated = hasSessionCookie(request)
+
+  if (isRoute(pathname, protectedRoutes) && !isAuthenticated) {
+    return redirectToLogin(request)
+  }
+
+  if (isRoute(pathname, authRoutes) && isAuthenticated) {
+    return NextResponse.redirect(new URL('/client', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/client/:path*', '/member/:path*', '/login', '/register'],
+}


### PR DESCRIPTION
## Resume
- Ajoute un `proxy.ts` Next.js 16 pour pre-filtrer les routes protegees.
- Redirige les visiteurs non authentifies vers `/login` avec `callbackUrl`.
- Redirige les utilisateurs deja authentifies hors de `/login` et `/register`.

## Changements
- Protection optimiste de `/client/*` et `/member/*` via cookie BetterAuth.
- Support des cookies `better-auth.session_token` et `__Secure-better-auth.session_token`.
- Matcher limite aux routes utiles pour eviter de faire tourner le proxy sur les assets/API.

## Commits
- `c735dc7 feat: add auth proxy`

## Points d'attention
- Le proxy ne fait pas d'appel DB : il lit seulement le cookie, conformement aux recommandations Next.js.
- Les layouts serveur restent la vraie protection de securite avec `getSession()`.
- Le proxy ne gere pas les roles : `/member` garde son check DB dans le layout membre.

## Tests
- `pnpm exec tsc --noEmit --pretty false` - OK local
- `pnpm exec eslint proxy.ts` - OK local
- Pre-push: `pnpm typecheck` - OK
- Pre-push: `pnpm lint` - OK
- Pre-push: `pnpm test` - 8 fichiers, 15 tests OK
- Pre-push: `pnpm test:integration` - 5 fichiers, 20 tests OK
- Pre-push: `pnpm build:check` - OK, Proxy detecte par Next.js