### PR TITLE
feat: verify email flow

### DIFF
--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -1,7 +1,14 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { Mail } from 'lucide-react'
+import { getSession } from '@/lib/auth'
 import { AuthShell } from '@/components/auth/auth-shell'
+import { ResendVerificationEmailButton } from '@/components/auth/resend-verification-email-button'
+
+interface Props {
+  searchParams: Promise<{ email?: string }>
+}
 
 export const metadata: Metadata = {
   title: 'Verification email',
@@ -9,7 +16,15 @@ export const metadata: Metadata = {
   robots: { index: false },
 }
 
-export default function VerifyEmailPage() {
+export default async function VerifyEmailPage({ searchParams }: Props) {
+  const session = await getSession()
+
+  if (session?.user.emailVerified) {
+    redirect('/client')
+  }
+
+  const { email } = await searchParams
+
   return (
     <AuthShell
       title="Verifiez votre email"
@@ -41,6 +56,8 @@ export default function VerifyEmailPage() {
             </Link>
           </span>
         </p>
+
+        <ResendVerificationEmailButton email={email} />
       </div>
 
       <p className="text-muted-foreground mt-8 text-center text-sm">

--- a/app/(auth)/verify-email/success/page.tsx
+++ b/app/(auth)/verify-email/success/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import { AuthShell } from '@/components/auth/auth-shell'
+import { EmailVerificationSuccessRedirect } from '@/components/auth/email-verification-success-redirect'
+
+export const metadata: Metadata = {
+  title: 'Email verifie - CutBook',
+  description: 'Votre adresse email est verifiee. Redirection vers votre espace CutBook.',
+  robots: { index: false },
+}
+
+export default function VerifyEmailSuccessPage() {
+  return (
+    <AuthShell
+      title="Verification terminee"
+      description="Votre compte CutBook est maintenant actif."
+      brandTitle="Bienvenue sur CutBook"
+      brandHighlight="votre espace est pret."
+      brandDescription="Vous pouvez maintenant gerer vos reservations, services et clients."
+    >
+      <EmailVerificationSuccessRedirect />
+    </AuthShell>
+  )
+}

--- a/components/auth/email-verification-success-redirect.test.tsx
+++ b/components/auth/email-verification-success-redirect.test.tsx
@@ -1,0 +1,36 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
+import { EmailVerificationSuccessRedirect } from './email-verification-success-redirect'
+
+describe('EmailVerificationSuccessRedirect', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: '' },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('redirige vers /client apres 5 secondes', () => {
+    render(<EmailVerificationSuccessRedirect />)
+
+    expect(screen.getByText(/Redirection vers ton espace dans 5s/i)).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    expect(window.location.href).toBe('/client')
+  })
+})

--- a/components/auth/email-verification-success-redirect.tsx
+++ b/components/auth/email-verification-success-redirect.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
+
+const REDIRECT_DELAY_SECONDS = 5
+
+export function EmailVerificationSuccessRedirect() {
+  const [remainingSeconds, setRemainingSeconds] = useState(REDIRECT_DELAY_SECONDS)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setRemainingSeconds((seconds) => Math.max(seconds - 1, 0))
+    }, 1000)
+
+    const redirect = window.setTimeout(() => {
+      window.location.href = '/client'
+    }, REDIRECT_DELAY_SECONDS * 1000)
+
+    return () => {
+      window.clearInterval(timer)
+      window.clearTimeout(redirect)
+    }
+  }, [])
+
+  return (
+    <div className="bg-card space-y-4 rounded-xl border p-8 text-center shadow-sm">
+      <div className="flex justify-center">
+        <div className="bg-primary/10 flex size-16 items-center justify-center rounded-full">
+          <CheckCircle2 className="text-primary size-8" />
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight">Email verifie</h2>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+          Ton compte est active. Redirection vers ton espace dans {remainingSeconds}s.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/auth/login-form.test.tsx
+++ b/components/auth/login-form.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LoginForm } from './login-form'
 
 const authMocks = vi.hoisted(() => ({
@@ -16,6 +16,11 @@ vi.mock('@/lib/auth/client', () => ({
 }))
 
 describe('LoginForm', () => {
+  beforeEach(() => {
+    authMocks.signInEmail.mockReset()
+    authMocks.signInSocial.mockReset()
+  })
+
   it('connecte avec BetterAuth email et redirige vers /client en succes', async () => {
     const user = userEvent.setup()
     const originalLocation = window.location
@@ -56,11 +61,17 @@ describe('LoginForm', () => {
     })
   })
 
-  it("affiche un message quand l'email n'est pas verifie", async () => {
+  it("redirige vers la verification email quand l'email n'est pas verifie", async () => {
     const user = userEvent.setup()
+    const originalLocation = window.location
 
     authMocks.signInEmail.mockImplementation(async ({ fetchOptions }) => {
       fetchOptions.onResponse({ response: { status: 403 } })
+    })
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: '' },
     })
 
     render(<LoginForm />)
@@ -69,8 +80,13 @@ describe('LoginForm', () => {
     await user.type(screen.getByLabelText('Mot de passe'), 'password-123')
     await user.click(screen.getByRole('button', { name: 'Se connecter' }))
 
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Vérifie ton email avant de te connecter.',
-    )
+    await waitFor(() => {
+      expect(window.location.href).toBe('/verify-email?email=client%40example.com')
+    })
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
   })
 })

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -60,8 +60,7 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
             setIsLoading(false)
           }
           if (ctx.response.status === 403) {
-            setServerError('Vérifie ton email avant de te connecter.')
-            setIsLoading(false)
+            window.location.href = `/verify-email?email=${encodeURIComponent(values.email)}`
           }
         },
         onSuccess: () => {

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -61,7 +61,7 @@ export function RegisterForm() {
         },
         onSuccess: () => {
           // Redirect vers page de vérification email
-          window.location.href = '/verify-email'
+          window.location.href = `/verify-email?email=${encodeURIComponent(values.email)}`
         },
         onError: () => {
           setServerError('Une erreur est survenue. Réessaie.')

--- a/components/auth/resend-verification-email-button.test.tsx
+++ b/components/auth/resend-verification-email-button.test.tsx
@@ -1,0 +1,53 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResendVerificationEmailButton } from './resend-verification-email-button'
+
+const authMocks = vi.hoisted(() => ({
+  sendVerificationEmail: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/client', () => ({
+  authClient: {
+    sendVerificationEmail: authMocks.sendVerificationEmail,
+  },
+}))
+
+describe('ResendVerificationEmailButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    authMocks.sendVerificationEmail.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('active le renvoi apres 60 secondes puis relance le compte a rebours', async () => {
+    authMocks.sendVerificationEmail.mockImplementation(async ({ fetchOptions }) => {
+      fetchOptions.onSuccess()
+    })
+
+    render(<ResendVerificationEmailButton email="client@example.com" />)
+
+    const button = screen.getByRole('button', { name: 'Renvoyer dans 60s' })
+    expect(button).toBeDisabled()
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Renvoyer le mail' }))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(authMocks.sendVerificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'client@example.com',
+        callbackURL: '/verify-email/success',
+      }),
+    )
+    expect(screen.getByRole('button', { name: 'Renvoyer dans 60s' })).toBeDisabled()
+  })
+})

--- a/components/auth/resend-verification-email-button.tsx
+++ b/components/auth/resend-verification-email-button.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2, MailPlus } from 'lucide-react'
+import { authClient } from '@/lib/auth/client'
+import { Button } from '@/components/ui/button'
+
+interface ResendVerificationEmailButtonProps {
+  email?: string
+}
+
+const RESEND_DELAY_SECONDS = 60
+
+export function ResendVerificationEmailButton({ email }: ResendVerificationEmailButtonProps) {
+  const [remainingSeconds, setRemainingSeconds] = useState(RESEND_DELAY_SECONDS)
+  const [isSending, setIsSending] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const canResend = !!email && remainingSeconds === 0 && !isSending
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setRemainingSeconds((seconds) => Math.max(seconds - 1, 0))
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  async function resendEmail() {
+    if (!email || !canResend) {
+      return
+    }
+
+    setIsSending(true)
+    setMessage(null)
+
+    await authClient.sendVerificationEmail({
+      email,
+      callbackURL: '/verify-email/success',
+      fetchOptions: {
+        onSuccess: () => {
+          setMessage('Email renvoye. Verifie ta boite de reception.')
+          setRemainingSeconds(RESEND_DELAY_SECONDS)
+          setIsSending(false)
+        },
+        onError: () => {
+          setMessage("Impossible de renvoyer l'email pour le moment.")
+          setIsSending(false)
+        },
+      },
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        disabled={!canResend}
+        onClick={resendEmail}
+      >
+        {isSending ? (
+          <>
+            <Loader2 className="animate-spin" />
+            Envoi en cours...
+          </>
+        ) : remainingSeconds > 0 ? (
+          <>Renvoyer dans {remainingSeconds}s</>
+        ) : (
+          <>
+            <MailPlus />
+            Renvoyer le mail
+          </>
+        )}
+      </Button>
+
+      {!email && (
+        <p className="text-muted-foreground text-xs">
+          Reconnecte-toi pour relancer automatiquement l&apos;envoi.
+        </p>
+      )}
+
+      {message && <p className="text-muted-foreground text-xs">{message}</p>}
+    </div>
+  )
+}

--- a/lib/auth/_config.ts
+++ b/lib/auth/_config.ts
@@ -7,6 +7,21 @@ import { db } from '@/lib/db'
 import { sendEmail, VerifyEmailTemplate } from '@/lib/email'
 import { env, getServerAppUrl } from '@/lib/env'
 
+function getVerificationSuccessUrl(url: string) {
+  try {
+    const verificationUrl = new URL(url)
+    const callbackUrl = verificationUrl.searchParams.get('callbackURL')
+
+    if (!callbackUrl || callbackUrl === '/') {
+      verificationUrl.searchParams.set('callbackURL', `${getServerAppUrl()}/verify-email/success`)
+    }
+
+    return verificationUrl.toString()
+  } catch {
+    return url
+  }
+}
+
 export const authConfig = betterAuth({
   database: prismaAdapter(db, {
     provider: 'postgresql',
@@ -26,11 +41,13 @@ export const authConfig = betterAuth({
     autoSignInAfterVerification: true,
     expiresIn: 60 * 60,
     sendVerificationEmail: async ({ user, url }) => {
+      const verificationUrl = getVerificationSuccessUrl(url)
+
       await sendEmail({
         to: user.email,
         subject: 'Confirme ton email CutBook',
-        react: VerifyEmailTemplate({ name: user.name, verificationUrl: url }),
-        text: `Confirme ton adresse email CutBook : ${url}`,
+        react: VerifyEmailTemplate({ name: user.name, verificationUrl }),
+        text: `Confirme ton adresse email CutBook : ${verificationUrl}`,
         tags: [
           {
             name: 'type',


### PR DESCRIPTION
## Resume
- Redirige les comptes non verifies vers la page de verification email.
- Ajoute le renvoi du mail de verification avec cooldown de 60 secondes.
- Ajoute une page de succes apres verification avec redirection automatique vers `/client`.

## Changements
- Auth: normalise le callback des mails BetterAuth vers `/verify-email/success` quand aucun callback explicite n'est fourni.
- UI verification: ajoute un bouton de renvoi visible mais desactive avec compteur, puis appel `sendVerificationEmail`.
- Routing: redirige `/verify-email` vers `/client` si la session courante est deja verifiee.
- Success page: cree `/verify-email/success` avec timer 5 secondes avant `/client`.
- Tests: couvre login non verifie, bouton de renvoi et redirection de succes.

## Commits
- `3adafd9 feat: verify email flow`

## Points d'attention
- Le renvoi manuel utilise l'email passe dans l'URL `/verify-email?email=...`; sans email, le bouton reste inutilisable et invite a se reconnecter.
- Warning non bloquant observe pendant le pre-push sur le mode SSL PostgreSQL (`sslmode=require/prefer`). Aucun check n'a echoue.

## Tests
- `pnpm typecheck` - OK
- `pnpm exec vitest run components/auth/login-form.test.tsx components/auth/resend-verification-email-button.test.tsx components/auth/email-verification-success-redirect.test.tsx` - OK
- `pnpm lint` - OK
- `pnpm test` - OK, 18 tests
- `pnpm test:integration` - OK, 20 tests
- `pnpm build:check` - OK