### PR TITLE
feat: add trpc routes

### DIFF
--- a/app/(public)/[org-slug]/booking/slot/page.tsx
+++ b/app/(public)/[org-slug]/booking/slot/page.tsx
@@ -20,7 +20,10 @@ export const metadata: Metadata = {
 export default async function PublicBookingSlotPage({ params, searchParams }: Props) {
   const { 'org-slug': orgSlug } = await params
   const { service, member } = await searchParams
-  const slots = await listPublicOrganizationAvailableSlots(orgSlug, { memberId: member })
+  const slots = await listPublicOrganizationAvailableSlots(orgSlug, {
+    memberId: member,
+    serviceId: service,
+  })
   const slotDates = listPublicSlotDates(slots)
   const publicSlots = slots.map((slot) => ({
     id: slot.id,

--- a/components/booking/public-booking-selector.test.tsx
+++ b/components/booking/public-booking-selector.test.tsx
@@ -17,8 +17,17 @@ const members = [
   {
     id: 'member-mila',
     specialties: 'Coupe femme',
+    services: [{ serviceId: 'service-cut' }],
     user: {
       name: 'Mila Laurent',
+    },
+  },
+  {
+    id: 'member-leo',
+    specialties: 'Barbe',
+    services: [{ serviceId: 'service-beard' }],
+    user: {
+      name: 'Leo Martin',
     },
   },
 ]
@@ -35,6 +44,7 @@ describe('PublicBookingSelector', () => {
     await user.click(screen.getByRole('radio', { name: /Coupe simple/ }))
     expect(nextLink).toHaveAttribute('aria-disabled', 'true')
     expect(nextLink).not.toHaveAttribute('href')
+    expect(screen.queryByLabelText(/Leo Martin/)).not.toBeInTheDocument()
 
     await user.click(screen.getByLabelText(/Mila Laurent/))
     const enabledNextLink = screen.getByRole('link', { name: 'Choisir un creneau' })

--- a/components/booking/public-booking-selector.tsx
+++ b/components/booking/public-booking-selector.tsx
@@ -17,6 +17,9 @@ interface PublicBookingSelectorProps {
   members: Array<{
     id: string
     specialties: string | null
+    services?: Array<{
+      serviceId: string
+    }>
     user: {
       name: string
     }
@@ -27,6 +30,32 @@ export function PublicBookingSelector({ orgSlug, services, members }: PublicBook
   const [serviceId, setServiceId] = useState('')
   const [memberId, setMemberId] = useState('')
   const canContinue = serviceId.length > 0 && memberId.length > 0
+  const availableMembers = useMemo(() => {
+    if (!serviceId) {
+      return members
+    }
+
+    return members.filter((member) =>
+      (member.services ?? []).some((service) => service.serviceId === serviceId),
+    )
+  }, [members, serviceId])
+
+  function handleServiceChange(nextServiceId: string) {
+    setServiceId(nextServiceId)
+
+    if (!memberId) {
+      return
+    }
+
+    const selectedMember = members.find((member) => member.id === memberId)
+    const selectedMemberCanDoService = selectedMember?.services?.some(
+      (service) => service.serviceId === nextServiceId,
+    )
+
+    if (!selectedMemberCanDoService) {
+      setMemberId('')
+    }
+  }
 
   const slotHref = useMemo(() => {
     if (!canContinue) {
@@ -59,7 +88,7 @@ export function PublicBookingSelector({ orgSlug, services, members }: PublicBook
                 name="service"
                 value={service.id}
                 checked={serviceId === service.id}
-                onChange={() => setServiceId(service.id)}
+                onChange={() => handleServiceChange(service.id)}
                 className="mt-0.5 accent-green-500"
               />
               <span className="flex-1">
@@ -81,7 +110,7 @@ export function PublicBookingSelector({ orgSlug, services, members }: PublicBook
           Choisissez un professionnel
         </h2>
         <div className="grid gap-3 sm:grid-cols-2">
-          {members.map((member) => (
+          {availableMembers.map((member) => (
             <label
               key={member.id}
               className="border-border bg-card flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-slate-50"
@@ -107,6 +136,11 @@ export function PublicBookingSelector({ orgSlug, services, members }: PublicBook
               </span>
             </label>
           ))}
+          {serviceId && availableMembers.length === 0 && (
+            <p className="text-sm text-slate-500">
+              Aucun professionnel ne propose encore ce service.
+            </p>
+          )}
         </div>
       </section>
 

--- a/docs/trpc-routes.md
+++ b/docs/trpc-routes.md
@@ -1,0 +1,316 @@
+# Routes tRPC
+
+Reference simple des routeurs tRPC metier disponibles dans `lib/trpc/routers/`.
+
+## Vue D'ensemble
+
+| Routeur        | Role                                              | Fichier                         |
+| -------------- | ------------------------------------------------- | ------------------------------- |
+| `booking`      | Confirmer et annuler une reservation              | `lib/trpc/routers/booking.ts`   |
+| `service`      | Gerer les prestations d'un salon                  | `lib/trpc/routers/service.ts`   |
+| `timeSlot`     | Gerer les creneaux et verifier leur disponibilite | `lib/trpc/routers/time-slot.ts` |
+| `clientPortal` | Donnees formatees pour le dashboard client        | `lib/trpc/routers/client.ts`    |
+| `memberPortal` | Donnees formatees pour le dashboard coiffeur      | `lib/trpc/routers/member.ts`    |
+
+Les routes metier sont exposees dans `lib/trpc/routers/index.ts`.
+
+## Booking
+
+### `booking.confirm`
+
+Confirme une prise de rendez-vous depuis le flow public.
+
+```ts
+await trpc.booking.confirm.mutate({
+  orgSlug: 'atelier-nova',
+  serviceId: 'service-id',
+  memberId: 'member-id',
+  slotId: 'slot-id',
+})
+```
+
+Regles :
+
+- utilisateur connecte obligatoire ;
+- le service doit appartenir au salon ;
+- le creneau doit appartenir au coiffeur choisi ;
+- le creneau doit encore etre disponible au moment de la transaction ;
+- le creneau est verrouille avec `isAvailable: false` ;
+- le booking est cree en `CONFIRMED`.
+
+Retour :
+
+```ts
+{
+  bookingId: string
+}
+```
+
+### `booking.confirmPublic`
+
+Alias temporaire de `booking.confirm`.
+
+Il existe uniquement pour ne pas casser l'UI actuelle. Les nouveaux appels doivent utiliser `booking.confirm`.
+
+### `booking.cancel`
+
+Annule une reservation.
+
+```ts
+await trpc.booking.cancel.mutate({
+  bookingId: 'booking-id',
+})
+```
+
+Regles :
+
+- utilisateur connecte obligatoire ;
+- autorise si l'utilisateur est le client du booking ;
+- autorise si l'utilisateur est le coiffeur du booking ;
+- autorise si l'utilisateur est le owner du salon ;
+- refuse une reservation `COMPLETED` ;
+- passe le booking en `CANCELLED` ;
+- remet le creneau associe en `isAvailable: true`.
+
+Retour :
+
+```ts
+{
+  bookingId: string
+  status: 'CANCELLED'
+}
+```
+
+## Service
+
+### `service.listByOrganization`
+
+Liste les services d'un salon.
+
+```ts
+await trpc.service.listByOrganization.query({
+  orgId: 'organization-id',
+})
+```
+
+Acces :
+
+- owner du salon ;
+- membre du salon.
+
+### `service.create`
+
+Cree une prestation.
+
+```ts
+await trpc.service.create.mutate({
+  orgId: 'organization-id',
+  name: 'Coupe homme',
+  description: 'Coupe et finitions',
+  duration: 45,
+  price: 35,
+})
+```
+
+Acces :
+
+- owner du salon uniquement.
+
+Contraintes :
+
+- `name` : 2 a 80 caracteres ;
+- `description` : optionnelle, 500 caracteres max ;
+- `duration` : 5 a 480 minutes ;
+- `price` : 0 a 10 000.
+
+### `service.update`
+
+Met a jour une prestation.
+
+```ts
+await trpc.service.update.mutate({
+  serviceId: 'service-id',
+  name: 'Coupe homme premium',
+  price: 45,
+})
+```
+
+Acces :
+
+- owner du salon uniquement.
+
+Au moins un champ modifiable doit etre fourni.
+
+### `service.delete`
+
+Supprime une prestation.
+
+```ts
+await trpc.service.delete.mutate({
+  serviceId: 'service-id',
+})
+```
+
+Acces :
+
+- owner du salon uniquement.
+
+Regle importante :
+
+- suppression refusee si le service est deja lie a une reservation.
+
+Retour :
+
+```ts
+{
+  serviceId: string
+}
+```
+
+## TimeSlot
+
+### `timeSlot.listByMember`
+
+Liste les creneaux d'un coiffeur.
+
+```ts
+await trpc.timeSlot.listByMember.query({
+  memberId: 'member-id',
+})
+```
+
+Acces :
+
+- coiffeur concerne ;
+- owner du salon.
+
+### `timeSlot.checkAvailability`
+
+Verifie si un creneau est encore disponible.
+
+```ts
+await trpc.timeSlot.checkAvailability.query({
+  timeSlotId: 'slot-id',
+})
+```
+
+Retour :
+
+```ts
+{
+  timeSlotId: string
+  isAvailable: boolean
+}
+```
+
+Cette route sert a l'UX. La vraie protection contre le double-booking reste dans `booking.confirm`.
+
+### `timeSlot.create`
+
+Cree un creneau.
+
+```ts
+await trpc.timeSlot.create.mutate({
+  memberId: 'member-id',
+  date: new Date('2026-06-01'),
+  startTime: '09:00',
+  endTime: '10:00',
+  isAvailable: true,
+})
+```
+
+Acces :
+
+- coiffeur concerne ;
+- owner du salon.
+
+Contraintes :
+
+- `startTime` et `endTime` au format `HH:mm` ;
+- `endTime` doit etre apres `startTime` ;
+- un meme coiffeur ne peut pas avoir deux creneaux avec la meme date et la meme heure de debut.
+
+### `timeSlot.update`
+
+Met a jour un creneau.
+
+```ts
+await trpc.timeSlot.update.mutate({
+  timeSlotId: 'slot-id',
+  startTime: '10:00',
+  endTime: '11:00',
+  isAvailable: false,
+})
+```
+
+Acces :
+
+- coiffeur concerne ;
+- owner du salon.
+
+Regles :
+
+- refuse si le creneau est lie a une reservation ;
+- au moins un champ modifiable doit etre fourni.
+
+### `timeSlot.delete`
+
+Supprime un creneau.
+
+```ts
+await trpc.timeSlot.delete.mutate({
+  timeSlotId: 'slot-id',
+})
+```
+
+Acces :
+
+- coiffeur concerne ;
+- owner du salon.
+
+Regle importante :
+
+- suppression refusee si le creneau est lie a une reservation.
+
+Retour :
+
+```ts
+{
+  timeSlotId: string
+}
+```
+
+## Usage Cote React
+
+Exemple mutation :
+
+```tsx
+const utils = trpc.useUtils()
+
+const cancelBooking = trpc.booking.cancel.useMutation({
+  onSuccess: () => {
+    utils.clientPortal.upcomingBookings.invalidate()
+    utils.clientPortal.bookingHistory.invalidate()
+  },
+})
+```
+
+Exemple appel :
+
+```tsx
+cancelBooking.mutate({ bookingId })
+```
+
+## Tests
+
+Tests d'integration principaux :
+
+- `lib/trpc/routers/booking.integration.test.ts`
+- `lib/trpc/routers/service.integration.test.ts`
+- `lib/trpc/routers/time-slot.integration.test.ts`
+
+Commande cible :
+
+```bash
+pnpm exec vitest run --config vitest.integration.config.ts lib/trpc/routers/booking.integration.test.ts lib/trpc/routers/service.integration.test.ts lib/trpc/routers/time-slot.integration.test.ts
+```

--- a/docs/trpc-routes.md
+++ b/docs/trpc-routes.md
@@ -33,6 +33,7 @@ Regles :
 
 - utilisateur connecte obligatoire ;
 - le service doit appartenir au salon ;
+- le service doit etre propose par le professionnel choisi ;
 - le creneau doit appartenir au coiffeur choisi ;
 - le creneau doit encore etre disponible au moment de la transaction ;
 - le creneau est verrouille avec `isAvailable: false` ;
@@ -109,6 +110,7 @@ await trpc.service.create.mutate({
   description: 'Coupe et finitions',
   duration: 45,
   price: 35,
+  memberIds: ['member-id'],
 })
 ```
 
@@ -122,6 +124,7 @@ Contraintes :
 - `description` : optionnelle, 500 caracteres max ;
 - `duration` : 5 a 480 minutes ;
 - `price` : 0 a 10 000.
+- `memberIds` : optionnel, associe directement le service aux professionnels capables de le faire.
 
 ### `service.update`
 
@@ -164,6 +167,37 @@ Retour :
 ```ts
 {
   serviceId: string
+}
+```
+
+### `service.setMemberServices`
+
+Definit les services qu'un professionnel peut proposer.
+
+```ts
+await trpc.service.setMemberServices.mutate({
+  memberId: 'member-id',
+  serviceIds: ['service-cut', 'service-color'],
+})
+```
+
+Acces :
+
+- owner du salon ;
+- professionnel concerne.
+
+Regles :
+
+- tous les services doivent appartenir au meme salon que le professionnel ;
+- la liste remplace les associations existantes du professionnel ;
+- une liste vide signifie que le professionnel ne propose aucun service.
+
+Retour :
+
+```ts
+{
+  memberId: string
+  serviceIds: string[]
 }
 ```
 

--- a/lib/bookings/public-booking.integration.test.ts
+++ b/lib/bookings/public-booking.integration.test.ts
@@ -64,6 +64,24 @@ describe('confirmPublicBooking', () => {
     })
   })
 
+  it('refuse un service non propose par le professionnel choisi', async () => {
+    resetPublicBookingRateLimit()
+
+    await expect(
+      confirmPublicBooking({
+        orgSlug: seedOrganization.slug,
+        clientId: seedUsers.clientOne.id,
+        serviceId: seedServices.cut.id,
+        memberId: seedMembers.leo.id,
+        slotId: 'seed-slot-leo-2',
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      code: 'SLOT_UNAVAILABLE',
+      message: 'Ce creneau nest plus disponible.',
+    })
+  })
+
   it('rate limit les confirmations repetees par client', async () => {
     resetPublicBookingRateLimit()
 

--- a/lib/bookings/public-booking.ts
+++ b/lib/bookings/public-booking.ts
@@ -78,6 +78,11 @@ export async function confirmPublicBooking(
           organization: {
             slug,
           },
+          members: {
+            some: {
+              memberId,
+            },
+          },
         },
         select: {
           id: true,

--- a/lib/organizations/public-organization.integration.test.ts
+++ b/lib/organizations/public-organization.integration.test.ts
@@ -93,6 +93,16 @@ describe('public organization data', () => {
     expect(slots.map((slot) => slot.id)).not.toContain('seed-slot-leo-2')
   })
 
+  it('filtre les creneaux par service selectionne', async () => {
+    const slots = await listPublicOrganizationAvailableSlots(seedOrganization.slug, {
+      serviceId: seedServices.beard.id,
+    })
+
+    expect(slots).not.toHaveLength(0)
+    expect(slots.every((slot) => slot.memberId === seedMembers.leo.id)).toBe(true)
+    expect(slots.map((slot) => slot.id)).not.toContain('seed-slot-mila-2')
+  })
+
   it('retourne une liste vide pour les creneaux d une organisation inconnue', async () => {
     await expect(listPublicOrganizationAvailableSlots('orga-inconnue')).resolves.toEqual([])
   })
@@ -122,6 +132,14 @@ describe('public organization data', () => {
       getPublicBookingConfirmationSummary(seedOrganization.slug, {
         serviceId: seedServices.cut.id,
         memberId: seedMembers.mila.id,
+      }),
+    ).resolves.toBeNull()
+
+    await expect(
+      getPublicBookingConfirmationSummary(seedOrganization.slug, {
+        serviceId: seedServices.cut.id,
+        memberId: seedMembers.leo.id,
+        slotId: 'seed-slot-leo-2',
       }),
     ).resolves.toBeNull()
 

--- a/lib/organizations/public-organization.ts
+++ b/lib/organizations/public-organization.ts
@@ -29,6 +29,11 @@ export async function getPublicOrganizationBySlug(orgSlug: string) {
       services: { orderBy: { price: 'asc' } },
       members: {
         include: {
+          services: {
+            select: {
+              serviceId: true,
+            },
+          },
           user: {
             select: {
               id: true,
@@ -44,6 +49,7 @@ export async function getPublicOrganizationBySlug(orgSlug: string) {
 
 interface PublicOrganizationSlotFilters {
   memberId?: string
+  serviceId?: string
 }
 
 export async function listPublicOrganizationAvailableSlots(
@@ -56,6 +62,15 @@ export async function listPublicOrganizationAvailableSlots(
     where: {
       member: {
         ...(filters.memberId ? { id: filters.memberId } : {}),
+        ...(filters.serviceId
+          ? {
+              services: {
+                some: {
+                  serviceId: filters.serviceId,
+                },
+              },
+            }
+          : {}),
         organization: {
           slug,
         },
@@ -108,7 +123,14 @@ export async function getPublicBookingConfirmationSummary(
       slug: true,
       name: true,
       services: {
-        where: { id: input.serviceId },
+        where: {
+          id: input.serviceId,
+          members: {
+            some: {
+              memberId: input.memberId,
+            },
+          },
+        },
         select: {
           id: true,
           name: true,
@@ -117,7 +139,14 @@ export async function getPublicBookingConfirmationSummary(
         },
       },
       members: {
-        where: { id: input.memberId },
+        where: {
+          id: input.memberId,
+          services: {
+            some: {
+              serviceId: input.serviceId,
+            },
+          },
+        },
         select: {
           id: true,
           user: {

--- a/lib/trpc/routers/booking.integration.test.ts
+++ b/lib/trpc/routers/booking.integration.test.ts
@@ -3,6 +3,7 @@
 import 'dotenv/config'
 
 import { beforeAll, describe, expect, it } from 'vitest'
+import type { TRPCError } from '@trpc/server'
 import { runSeed, seedMembers, seedOrganization, seedServices, seedUsers } from '@/prisma/seed'
 import { resetPublicBookingRateLimit } from '@/lib/bookings/public-booking'
 import { db } from '@/lib/db'
@@ -18,7 +19,49 @@ describe('bookingRouter', () => {
     resetPublicBookingRateLimit()
   })
 
+  async function createUserCaller(userId: string) {
+    const user = await db.user.findUniqueOrThrow({ where: { id: userId } })
+    const session = {
+      id: `test-session-${user.id}`,
+      token: `test-token-${user.id}`,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+    }
+
+    return appRouter.createCaller({
+      db,
+      session: { session, user },
+      user,
+    })
+  }
+
   it('confirme un booking avec le client de la session tRPC', async () => {
+    const caller = await createUserCaller(seedUsers.clientTwo.id)
+
+    const result = await caller.booking.confirm({
+      orgSlug: seedOrganization.slug,
+      serviceId: seedServices.beard.id,
+      memberId: seedMembers.leo.id,
+      slotId: 'seed-slot-leo-2',
+    })
+
+    expect(result).toEqual({ bookingId: expect.any(String) })
+
+    const booking = await db.booking.findUnique({
+      where: { id: result.bookingId },
+    })
+
+    expect(booking?.clientId).toBe(seedUsers.clientTwo.id)
+    expect(booking?.serviceId).toBe(seedServices.beard.id)
+    expect(booking?.memberId).toBe(seedMembers.leo.id)
+    expect(booking?.timeSlotId).toBe('seed-slot-leo-2')
+  })
+
+  it('garde confirmPublic comme alias temporaire', async () => {
     const user = await db.user.findUniqueOrThrow({ where: { id: seedUsers.clientTwo.id } })
     const session = {
       id: 'test-session',
@@ -40,7 +83,7 @@ describe('bookingRouter', () => {
       orgSlug: seedOrganization.slug,
       serviceId: seedServices.beard.id,
       memberId: seedMembers.leo.id,
-      slotId: 'seed-slot-leo-2',
+      slotId: 'seed-slot-leo-3',
     })
 
     expect(result).toEqual({ bookingId: expect.any(String) })
@@ -52,6 +95,35 @@ describe('bookingRouter', () => {
     expect(booking?.clientId).toBe(seedUsers.clientTwo.id)
     expect(booking?.serviceId).toBe(seedServices.beard.id)
     expect(booking?.memberId).toBe(seedMembers.leo.id)
-    expect(booking?.timeSlotId).toBe('seed-slot-leo-2')
+    expect(booking?.timeSlotId).toBe('seed-slot-leo-3')
+  })
+
+  it('annule un booking et libere le creneau associe', async () => {
+    const caller = await createUserCaller(seedUsers.clientOne.id)
+
+    const result = await caller.booking.cancel({ bookingId: 'seed-booking-confirmed' })
+
+    expect(result).toEqual({
+      bookingId: 'seed-booking-confirmed',
+      status: 'CANCELLED',
+    })
+
+    const booking = await db.booking.findUniqueOrThrow({
+      where: { id: 'seed-booking-confirmed' },
+      include: { timeSlot: true },
+    })
+
+    expect(booking.status).toBe('CANCELLED')
+    expect(booking.timeSlot.isAvailable).toBe(true)
+  })
+
+  it('refuse l annulation par un autre client', async () => {
+    const caller = await createUserCaller(seedUsers.clientTwo.id)
+
+    await expect(
+      caller.booking.cancel({ bookingId: 'seed-booking-confirmed' }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN' satisfies TRPCError['code'],
+    })
   })
 })

--- a/lib/trpc/routers/booking.ts
+++ b/lib/trpc/routers/booking.ts
@@ -4,29 +4,106 @@ import {
   confirmPublicBooking,
   confirmPublicBookingSelectionSchema,
 } from '@/lib/bookings/public-booking'
+import { BookingStatus } from '@/generated/prisma/enums'
 import { protectedProcedure, router } from '../init'
+import { z } from 'zod'
+
+const confirmBookingProcedure = protectedProcedure
+  .input(confirmPublicBookingSelectionSchema)
+  .mutation(async ({ ctx, input }) => {
+    const result = await confirmPublicBooking({
+      ...input,
+      clientId: ctx.user.id,
+    })
+
+    if (result.ok) {
+      return { bookingId: result.bookingId }
+    }
+
+    if (result.code === 'RATE_LIMITED') {
+      throw new TRPCError({ code: 'TOO_MANY_REQUESTS', message: result.message })
+    }
+
+    if (result.code === 'SLOT_UNAVAILABLE') {
+      throw new TRPCError({ code: 'CONFLICT', message: result.message })
+    }
+
+    throw new TRPCError({ code: 'BAD_REQUEST', message: result.message })
+  })
 
 export const bookingRouter = router({
-  confirmPublic: protectedProcedure
-    .input(confirmPublicBookingSelectionSchema)
+  confirm: confirmBookingProcedure,
+
+  // Alias temporaire pour garder le flow public actuel fonctionnel pendant la migration UI.
+  confirmPublic: confirmBookingProcedure,
+
+  cancel: protectedProcedure
+    .input(z.object({ bookingId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const result = await confirmPublicBooking({
-        ...input,
-        clientId: ctx.user.id,
+      const booking = await ctx.db.booking.findUnique({
+        where: { id: input.bookingId },
+        include: {
+          member: {
+            select: {
+              userId: true,
+              organization: {
+                select: {
+                  ownerId: true,
+                },
+              },
+            },
+          },
+        },
       })
 
-      if (result.ok) {
-        return { bookingId: result.bookingId }
+      if (!booking) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Reservation introuvable.' })
       }
 
-      if (result.code === 'RATE_LIMITED') {
-        throw new TRPCError({ code: 'TOO_MANY_REQUESTS', message: result.message })
+      const canCancel =
+        booking.clientId === ctx.user.id ||
+        booking.member.userId === ctx.user.id ||
+        booking.member.organization.ownerId === ctx.user.id
+
+      if (!canCancel) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Vous ne pouvez pas annuler cette reservation.',
+        })
       }
 
-      if (result.code === 'SLOT_UNAVAILABLE') {
-        throw new TRPCError({ code: 'CONFLICT', message: result.message })
+      if (booking.status === BookingStatus.COMPLETED) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Une reservation terminee ne peut pas etre annulee.',
+        })
       }
 
-      throw new TRPCError({ code: 'BAD_REQUEST', message: result.message })
+      if (booking.status === BookingStatus.CANCELLED) {
+        return { bookingId: booking.id, status: booking.status }
+      }
+
+      const cancelledBooking = await ctx.db.$transaction(async (tx) => {
+        const updatedBooking = await tx.booking.update({
+          where: { id: booking.id },
+          data: { status: BookingStatus.CANCELLED },
+          select: {
+            id: true,
+            status: true,
+          },
+        })
+
+        await tx.timeSlot.update({
+          where: { id: booking.timeSlotId },
+          data: { isAvailable: true },
+        })
+
+        return updatedBooking
+      })
+
+      return {
+        bookingId: cancelledBooking.id,
+        status: cancelledBooking.status,
+      }
     }),
 })

--- a/lib/trpc/routers/index.ts
+++ b/lib/trpc/routers/index.ts
@@ -5,13 +5,16 @@ import { bookingRouter } from './booking'
 import { clientRouter } from './client'
 import { memberRouter } from './member'
 import { organizationRouter } from './organization'
+import { serviceRouter } from './service'
+import { timeSlotRouter } from './time-slot'
 
 export const appRouter = router({
   organization: organizationRouter,
   booking: bookingRouter,
+  service: serviceRouter,
+  timeSlot: timeSlotRouter,
   clientPortal: clientRouter,
   memberPortal: memberRouter,
-  // service: serviceRouter,    // TODO
   // review: reviewRouter,      // TODO
   // reward: rewardRouter,      // TODO
 })

--- a/lib/trpc/routers/service.integration.test.ts
+++ b/lib/trpc/routers/service.integration.test.ts
@@ -4,7 +4,7 @@ import 'dotenv/config'
 
 import type { TRPCError } from '@trpc/server'
 import { beforeAll, describe, expect, it } from 'vitest'
-import { runSeed, seedOrganization, seedServices, seedUsers } from '@/prisma/seed'
+import { runSeed, seedMembers, seedOrganization, seedServices, seedUsers } from '@/prisma/seed'
 import { db } from '@/lib/db'
 import { appRouter } from '.'
 
@@ -61,6 +61,7 @@ describe('serviceRouter integration', () => {
       description: 'Soin cheveux test integration',
       duration: 30,
       price: 35,
+      memberIds: [seedMembers.mila.id],
     })
 
     expect(created).toMatchObject({
@@ -68,6 +69,13 @@ describe('serviceRouter integration', () => {
       name: 'Soin profond',
       price: 35,
     })
+    expect(created.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          memberId: seedMembers.mila.id,
+        }),
+      ]),
+    )
 
     const updated = await caller.service.update({
       serviceId: created.id,
@@ -99,5 +107,29 @@ describe('serviceRouter integration', () => {
     ).rejects.toMatchObject({
       code: 'FORBIDDEN' satisfies TRPCError['code'],
     })
+  })
+
+  it('permet au membre de choisir les services qu il propose', async () => {
+    const caller = await createUserCaller(seedUsers.memberOne.id)
+
+    const result = await caller.service.setMemberServices({
+      memberId: seedMembers.mila.id,
+      serviceIds: [seedServices.cut.id, seedServices.color.id],
+    })
+
+    expect(result).toEqual({
+      memberId: seedMembers.mila.id,
+      serviceIds: [seedServices.cut.id, seedServices.color.id],
+    })
+
+    const memberServices = await db.memberService.findMany({
+      where: { memberId: seedMembers.mila.id },
+      orderBy: { serviceId: 'asc' },
+    })
+
+    expect(memberServices.map((memberService) => memberService.serviceId).sort()).toEqual([
+      seedServices.color.id,
+      seedServices.cut.id,
+    ])
   })
 })

--- a/lib/trpc/routers/service.integration.test.ts
+++ b/lib/trpc/routers/service.integration.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import 'dotenv/config'
+
+import type { TRPCError } from '@trpc/server'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { runSeed, seedOrganization, seedServices, seedUsers } from '@/prisma/seed'
+import { db } from '@/lib/db'
+import { appRouter } from '.'
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL is required to run integration tests')
+}
+
+async function createUserCaller(userId: string) {
+  const user = await db.user.findUniqueOrThrow({ where: { id: userId } })
+  const session = {
+    id: `test-session-${user.id}`,
+    token: `test-token-${user.id}`,
+    userId: user.id,
+    expiresAt: new Date(Date.now() + 60_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: null,
+    userAgent: null,
+  }
+
+  return appRouter.createCaller({
+    db,
+    session: { session, user },
+    user,
+  })
+}
+
+describe('serviceRouter integration', () => {
+  beforeAll(async () => {
+    await runSeed()
+  }, 30_000)
+
+  it('liste les services du salon pour le owner', async () => {
+    const caller = await createUserCaller(seedUsers.owner.id)
+
+    const services = await caller.service.listByOrganization({ orgId: seedOrganization.id })
+
+    expect(services).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: seedServices.cut.id,
+          name: seedServices.cut.name,
+        }),
+      ]),
+    )
+  })
+
+  it('cree, met a jour puis supprime un service owner-only', async () => {
+    const caller = await createUserCaller(seedUsers.owner.id)
+
+    const created = await caller.service.create({
+      orgId: seedOrganization.id,
+      name: 'Soin profond',
+      description: 'Soin cheveux test integration',
+      duration: 30,
+      price: 35,
+    })
+
+    expect(created).toMatchObject({
+      orgId: seedOrganization.id,
+      name: 'Soin profond',
+      price: 35,
+    })
+
+    const updated = await caller.service.update({
+      serviceId: created.id,
+      name: 'Soin profond premium',
+      price: 45,
+    })
+
+    expect(updated).toMatchObject({
+      id: created.id,
+      name: 'Soin profond premium',
+      price: 45,
+    })
+
+    await expect(caller.service.delete({ serviceId: created.id })).resolves.toEqual({
+      serviceId: created.id,
+    })
+  })
+
+  it('refuse la creation de service par un membre', async () => {
+    const caller = await createUserCaller(seedUsers.memberOne.id)
+
+    await expect(
+      caller.service.create({
+        orgId: seedOrganization.id,
+        name: 'Service interdit',
+        duration: 30,
+        price: 20,
+      }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN' satisfies TRPCError['code'],
+    })
+  })
+})

--- a/lib/trpc/routers/service.ts
+++ b/lib/trpc/routers/service.ts
@@ -1,0 +1,173 @@
+// Router tRPC pour les prestations d'un salon.
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { protectedProcedure, router } from '../init'
+
+const serviceInputSchema = z.object({
+  orgId: z.string().min(1),
+  name: z.string().min(2).max(80),
+  description: z.string().max(500).nullable().optional(),
+  duration: z.number().int().min(5).max(480),
+  price: z.number().min(0).max(10_000),
+})
+
+const updateServiceSchema = serviceInputSchema
+  .omit({ orgId: true })
+  .partial()
+  .extend({
+    serviceId: z.string().min(1),
+  })
+  .refine(
+    ({ name, description, duration, price }) =>
+      name !== undefined ||
+      description !== undefined ||
+      duration !== undefined ||
+      price !== undefined,
+    'Au moins un champ doit etre renseigne.',
+  )
+
+async function ensureOrgAccess(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  orgId: string,
+) {
+  const organization = await ctx.db.organization.findUnique({
+    where: { id: orgId },
+    select: {
+      id: true,
+      ownerId: true,
+      members: {
+        where: { userId: ctx.user.id },
+        select: { id: true },
+      },
+    },
+  })
+
+  if (!organization) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Salon introuvable.' })
+  }
+
+  if (organization.ownerId !== ctx.user.id && organization.members.length === 0) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Vous ne pouvez pas acceder aux services de ce salon.',
+    })
+  }
+
+  return organization
+}
+
+async function ensureOrgOwner(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  orgId: string,
+) {
+  const organization = await ctx.db.organization.findUnique({
+    where: { id: orgId },
+    select: { id: true, ownerId: true },
+  })
+
+  if (!organization) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Salon introuvable.' })
+  }
+
+  if (organization.ownerId !== ctx.user.id) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Seul le proprietaire du salon peut modifier les services.',
+    })
+  }
+
+  return organization
+}
+
+async function getServiceForOwner(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  serviceId: string,
+) {
+  const service = await ctx.db.service.findUnique({
+    where: { id: serviceId },
+    select: {
+      id: true,
+      orgId: true,
+      organization: {
+        select: {
+          ownerId: true,
+        },
+      },
+    },
+  })
+
+  if (!service) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Service introuvable.' })
+  }
+
+  if (service.organization.ownerId !== ctx.user.id) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Seul le proprietaire du salon peut modifier ce service.',
+    })
+  }
+
+  return service
+}
+
+export const serviceRouter = router({
+  listByOrganization: protectedProcedure
+    .input(z.object({ orgId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      await ensureOrgAccess(ctx, input.orgId)
+
+      return await ctx.db.service.findMany({
+        where: { orgId: input.orgId },
+        orderBy: [{ name: 'asc' }],
+      })
+    }),
+
+  create: protectedProcedure.input(serviceInputSchema).mutation(async ({ ctx, input }) => {
+    await ensureOrgOwner(ctx, input.orgId)
+
+    return await ctx.db.service.create({
+      data: {
+        orgId: input.orgId,
+        name: input.name,
+        description: input.description ?? null,
+        duration: input.duration,
+        price: input.price,
+      },
+    })
+  }),
+
+  update: protectedProcedure.input(updateServiceSchema).mutation(async ({ ctx, input }) => {
+    const service = await getServiceForOwner(ctx, input.serviceId)
+
+    return await ctx.db.service.update({
+      where: { id: service.id },
+      data: {
+        name: input.name,
+        description: input.description,
+        duration: input.duration,
+        price: input.price,
+      },
+    })
+  }),
+
+  delete: protectedProcedure
+    .input(z.object({ serviceId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const service = await getServiceForOwner(ctx, input.serviceId)
+
+      const bookingsCount = await ctx.db.booking.count({
+        where: { serviceId: service.id },
+      })
+
+      if (bookingsCount > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Impossible de supprimer un service lie a des reservations.',
+        })
+      }
+
+      await ctx.db.service.delete({ where: { id: service.id } })
+
+      return { serviceId: service.id }
+    }),
+})

--- a/lib/trpc/routers/service.ts
+++ b/lib/trpc/routers/service.ts
@@ -9,10 +9,11 @@ const serviceInputSchema = z.object({
   description: z.string().max(500).nullable().optional(),
   duration: z.number().int().min(5).max(480),
   price: z.number().min(0).max(10_000),
+  memberIds: z.array(z.string().min(1)).optional(),
 })
 
 const updateServiceSchema = serviceInputSchema
-  .omit({ orgId: true })
+  .omit({ orgId: true, memberIds: true })
   .partial()
   .extend({
     serviceId: z.string().min(1),
@@ -110,6 +111,86 @@ async function getServiceForOwner(
   return service
 }
 
+async function ensureMembersBelongToOrg(
+  ctx: { db: typeof import('@/lib/db').db },
+  input: { orgId: string; memberIds: string[] },
+) {
+  if (input.memberIds.length === 0) {
+    return
+  }
+
+  const uniqueMemberIds = [...new Set(input.memberIds)]
+  const membersCount = await ctx.db.member.count({
+    where: {
+      id: { in: uniqueMemberIds },
+      orgId: input.orgId,
+    },
+  })
+
+  if (membersCount !== uniqueMemberIds.length) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Tous les professionnels doivent appartenir au salon.',
+    })
+  }
+}
+
+async function getMemberForServiceUpdate(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  memberId: string,
+) {
+  const member = await ctx.db.member.findUnique({
+    where: { id: memberId },
+    select: {
+      id: true,
+      orgId: true,
+      userId: true,
+      organization: {
+        select: {
+          ownerId: true,
+        },
+      },
+    },
+  })
+
+  if (!member) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Professionnel introuvable.' })
+  }
+
+  if (member.userId !== ctx.user.id && member.organization.ownerId !== ctx.user.id) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Vous ne pouvez pas modifier les services de ce professionnel.',
+    })
+  }
+
+  return member
+}
+
+async function ensureServicesBelongToOrg(
+  ctx: { db: typeof import('@/lib/db').db },
+  input: { orgId: string; serviceIds: string[] },
+) {
+  if (input.serviceIds.length === 0) {
+    return
+  }
+
+  const uniqueServiceIds = [...new Set(input.serviceIds)]
+  const servicesCount = await ctx.db.service.count({
+    where: {
+      id: { in: uniqueServiceIds },
+      orgId: input.orgId,
+    },
+  })
+
+  if (servicesCount !== uniqueServiceIds.length) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Tous les services doivent appartenir au salon.',
+    })
+  }
+}
+
 export const serviceRouter = router({
   listByOrganization: protectedProcedure
     .input(z.object({ orgId: z.string().min(1) }))
@@ -118,12 +199,32 @@ export const serviceRouter = router({
 
       return await ctx.db.service.findMany({
         where: { orgId: input.orgId },
+        include: {
+          members: {
+            select: {
+              memberId: true,
+              member: {
+                select: {
+                  user: {
+                    select: {
+                      name: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
         orderBy: [{ name: 'asc' }],
       })
     }),
 
   create: protectedProcedure.input(serviceInputSchema).mutation(async ({ ctx, input }) => {
     await ensureOrgOwner(ctx, input.orgId)
+    await ensureMembersBelongToOrg(ctx, {
+      orgId: input.orgId,
+      memberIds: input.memberIds ?? [],
+    })
 
     return await ctx.db.service.create({
       data: {
@@ -132,6 +233,16 @@ export const serviceRouter = router({
         description: input.description ?? null,
         duration: input.duration,
         price: input.price,
+        members: input.memberIds?.length
+          ? {
+              createMany: {
+                data: [...new Set(input.memberIds)].map((memberId) => ({ memberId })),
+              },
+            }
+          : undefined,
+      },
+      include: {
+        members: true,
       },
     })
   }),
@@ -169,5 +280,42 @@ export const serviceRouter = router({
       await ctx.db.service.delete({ where: { id: service.id } })
 
       return { serviceId: service.id }
+    }),
+
+  setMemberServices: protectedProcedure
+    .input(
+      z.object({
+        memberId: z.string().min(1),
+        serviceIds: z.array(z.string().min(1)),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const member = await getMemberForServiceUpdate(ctx, input.memberId)
+      const serviceIds = [...new Set(input.serviceIds)]
+
+      await ensureServicesBelongToOrg(ctx, {
+        orgId: member.orgId,
+        serviceIds,
+      })
+
+      await ctx.db.$transaction(async (tx) => {
+        await tx.memberService.deleteMany({
+          where: { memberId: member.id },
+        })
+
+        if (serviceIds.length > 0) {
+          await tx.memberService.createMany({
+            data: serviceIds.map((serviceId) => ({
+              memberId: member.id,
+              serviceId,
+            })),
+          })
+        }
+      })
+
+      return {
+        memberId: member.id,
+        serviceIds,
+      }
     }),
 })

--- a/lib/trpc/routers/time-slot.integration.test.ts
+++ b/lib/trpc/routers/time-slot.integration.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+
+import 'dotenv/config'
+
+import type { TRPCError } from '@trpc/server'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { dayFromNow, runSeed, seedMembers, seedUsers } from '@/prisma/seed'
+import { db } from '@/lib/db'
+import { appRouter } from '.'
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL is required to run integration tests')
+}
+
+async function createUserCaller(userId: string) {
+  const user = await db.user.findUniqueOrThrow({ where: { id: userId } })
+  const session = {
+    id: `test-session-${user.id}`,
+    token: `test-token-${user.id}`,
+    userId: user.id,
+    expiresAt: new Date(Date.now() + 60_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: null,
+    userAgent: null,
+  }
+
+  return appRouter.createCaller({
+    db,
+    session: { session, user },
+    user,
+  })
+}
+
+describe('timeSlotRouter integration', () => {
+  beforeAll(async () => {
+    await runSeed()
+  }, 30_000)
+
+  it('liste les creneaux du membre connecte', async () => {
+    const caller = await createUserCaller(seedUsers.memberOne.id)
+
+    const slots = await caller.timeSlot.listByMember({ memberId: seedMembers.mila.id })
+
+    expect(slots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'seed-slot-mila-1',
+          isAvailable: false,
+        }),
+        expect.objectContaining({
+          id: 'seed-slot-mila-2',
+          isAvailable: true,
+        }),
+      ]),
+    )
+  })
+
+  it('verifie la disponibilite reelle d un creneau', async () => {
+    const caller = await createUserCaller(seedUsers.memberOne.id)
+
+    await expect(
+      caller.timeSlot.checkAvailability({ timeSlotId: 'seed-slot-mila-1' }),
+    ).resolves.toEqual({
+      timeSlotId: 'seed-slot-mila-1',
+      isAvailable: false,
+    })
+
+    await expect(
+      caller.timeSlot.checkAvailability({ timeSlotId: 'seed-slot-mila-2' }),
+    ).resolves.toEqual({
+      timeSlotId: 'seed-slot-mila-2',
+      isAvailable: true,
+    })
+  })
+
+  it('cree, met a jour puis supprime un creneau', async () => {
+    const caller = await createUserCaller(seedUsers.memberOne.id)
+
+    const created = await caller.timeSlot.create({
+      memberId: seedMembers.mila.id,
+      date: dayFromNow(7),
+      startTime: '18:00',
+      endTime: '19:00',
+    })
+
+    expect(created).toMatchObject({
+      memberId: seedMembers.mila.id,
+      startTime: '18:00',
+      endTime: '19:00',
+      isAvailable: true,
+    })
+
+    const updated = await caller.timeSlot.update({
+      timeSlotId: created.id,
+      startTime: '18:30',
+      endTime: '19:30',
+      isAvailable: false,
+    })
+
+    expect(updated).toMatchObject({
+      id: created.id,
+      startTime: '18:30',
+      endTime: '19:30',
+      isAvailable: false,
+    })
+
+    await expect(caller.timeSlot.delete({ timeSlotId: created.id })).resolves.toEqual({
+      timeSlotId: created.id,
+    })
+  })
+
+  it('refuse de supprimer un creneau lie a une reservation', async () => {
+    const caller = await createUserCaller(seedUsers.owner.id)
+
+    await expect(caller.timeSlot.delete({ timeSlotId: 'seed-slot-mila-1' })).rejects.toMatchObject({
+      code: 'CONFLICT' satisfies TRPCError['code'],
+    })
+  })
+
+  it('refuse la gestion des creneaux par un autre client', async () => {
+    const caller = await createUserCaller(seedUsers.clientOne.id)
+
+    await expect(
+      caller.timeSlot.listByMember({ memberId: seedMembers.mila.id }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN' satisfies TRPCError['code'],
+    })
+  })
+})

--- a/lib/trpc/routers/time-slot.ts
+++ b/lib/trpc/routers/time-slot.ts
@@ -1,0 +1,244 @@
+// Router tRPC pour les creneaux de disponibilite.
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { protectedProcedure, router } from '../init'
+
+const timeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Format attendu : HH:mm')
+
+const timeSlotBaseSchema = z.object({
+  memberId: z.string().min(1),
+  date: z.coerce.date(),
+  startTime: timeSchema,
+  endTime: timeSchema,
+  isAvailable: z.boolean().optional(),
+})
+
+const timeSlotInputSchema = timeSlotBaseSchema.refine(
+  ({ startTime, endTime }) => startTime < endTime,
+  {
+    message: "L'heure de fin doit etre apres l'heure de debut.",
+    path: ['endTime'],
+  },
+)
+
+const updateTimeSlotSchema = timeSlotBaseSchema
+  .omit({ memberId: true })
+  .partial()
+  .extend({
+    timeSlotId: z.string().min(1),
+  })
+  .refine(
+    ({ date, startTime, endTime, isAvailable }) =>
+      date !== undefined ||
+      startTime !== undefined ||
+      endTime !== undefined ||
+      isAvailable !== undefined,
+    'Au moins un champ doit etre renseigne.',
+  )
+
+function toDateOnly(value: Date) {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()))
+}
+
+async function getMemberForAccess(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  memberId: string,
+) {
+  const member = await ctx.db.member.findUnique({
+    where: { id: memberId },
+    select: {
+      id: true,
+      userId: true,
+      organization: {
+        select: {
+          ownerId: true,
+        },
+      },
+    },
+  })
+
+  if (!member) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Professionnel introuvable.' })
+  }
+
+  if (member.userId !== ctx.user.id && member.organization.ownerId !== ctx.user.id) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Vous ne pouvez pas gerer les creneaux de ce professionnel.',
+    })
+  }
+
+  return member
+}
+
+async function getTimeSlotForAccess(
+  ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
+  timeSlotId: string,
+) {
+  const timeSlot = await ctx.db.timeSlot.findUnique({
+    where: { id: timeSlotId },
+    include: {
+      booking: {
+        select: { id: true },
+      },
+      member: {
+        select: {
+          userId: true,
+          organization: {
+            select: {
+              ownerId: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!timeSlot) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Creneau introuvable.' })
+  }
+
+  if (
+    timeSlot.member.userId !== ctx.user.id &&
+    timeSlot.member.organization.ownerId !== ctx.user.id
+  ) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Vous ne pouvez pas gerer ce creneau.',
+    })
+  }
+
+  return timeSlot
+}
+
+async function ensureNoSlotAtSameStart(
+  ctx: { db: typeof import('@/lib/db').db },
+  input: { memberId: string; date: Date; startTime: string; excludeTimeSlotId?: string },
+) {
+  const existingSlot = await ctx.db.timeSlot.findFirst({
+    where: {
+      memberId: input.memberId,
+      date: toDateOnly(input.date),
+      startTime: input.startTime,
+      ...(input.excludeTimeSlotId ? { id: { not: input.excludeTimeSlotId } } : {}),
+    },
+    select: { id: true },
+  })
+
+  if (existingSlot) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: 'Un creneau existe deja a cette heure.',
+    })
+  }
+}
+
+export const timeSlotRouter = router({
+  listByMember: protectedProcedure
+    .input(z.object({ memberId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      await getMemberForAccess(ctx, input.memberId)
+
+      return await ctx.db.timeSlot.findMany({
+        where: { memberId: input.memberId },
+        orderBy: [{ date: 'asc' }, { startTime: 'asc' }],
+      })
+    }),
+
+  checkAvailability: protectedProcedure
+    .input(z.object({ timeSlotId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const timeSlot = await ctx.db.timeSlot.findUnique({
+        where: { id: input.timeSlotId },
+        select: {
+          id: true,
+          isAvailable: true,
+          booking: {
+            select: { id: true },
+          },
+        },
+      })
+
+      if (!timeSlot) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Creneau introuvable.' })
+      }
+
+      return {
+        timeSlotId: timeSlot.id,
+        isAvailable: timeSlot.isAvailable && !timeSlot.booking,
+      }
+    }),
+
+  create: protectedProcedure.input(timeSlotInputSchema).mutation(async ({ ctx, input }) => {
+    await getMemberForAccess(ctx, input.memberId)
+    await ensureNoSlotAtSameStart(ctx, input)
+
+    return await ctx.db.timeSlot.create({
+      data: {
+        memberId: input.memberId,
+        date: toDateOnly(input.date),
+        startTime: input.startTime,
+        endTime: input.endTime,
+        isAvailable: input.isAvailable ?? true,
+      },
+    })
+  }),
+
+  update: protectedProcedure.input(updateTimeSlotSchema).mutation(async ({ ctx, input }) => {
+    const timeSlot = await getTimeSlotForAccess(ctx, input.timeSlotId)
+
+    if (timeSlot.booking) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Impossible de modifier un creneau lie a une reservation.',
+      })
+    }
+
+    const nextDate = input.date ? toDateOnly(input.date) : timeSlot.date
+    const nextStartTime = input.startTime ?? timeSlot.startTime
+    const nextEndTime = input.endTime ?? timeSlot.endTime
+
+    if (nextStartTime >= nextEndTime) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: "L'heure de fin doit etre apres l'heure de debut.",
+      })
+    }
+
+    if (input.date || input.startTime) {
+      await ensureNoSlotAtSameStart(ctx, {
+        memberId: timeSlot.memberId,
+        date: nextDate,
+        startTime: nextStartTime,
+        excludeTimeSlotId: timeSlot.id,
+      })
+    }
+
+    return await ctx.db.timeSlot.update({
+      where: { id: timeSlot.id },
+      data: {
+        date: input.date ? nextDate : undefined,
+        startTime: input.startTime,
+        endTime: input.endTime,
+        isAvailable: input.isAvailable,
+      },
+    })
+  }),
+
+  delete: protectedProcedure
+    .input(z.object({ timeSlotId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const timeSlot = await getTimeSlotForAccess(ctx, input.timeSlotId)
+
+      if (timeSlot.booking) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Impossible de supprimer un creneau lie a une reservation.',
+        })
+      }
+
+      await ctx.db.timeSlot.delete({ where: { id: timeSlot.id } })
+
+      return { timeSlotId: timeSlot.id }
+    }),
+})

--- a/prisma/migrations/20260520142000_add_member_services/migration.sql
+++ b/prisma/migrations/20260520142000_add_member_services/migration.sql
@@ -1,0 +1,12 @@
+-- Associate services with the members who can perform them.
+CREATE TABLE "member_service" (
+    "memberId" TEXT NOT NULL,
+    "serviceId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "member_service_pkey" PRIMARY KEY ("memberId","serviceId")
+);
+
+ALTER TABLE "member_service" ADD CONSTRAINT "member_service_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "member"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "member_service" ADD CONSTRAINT "member_service_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "service"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Member {
   timeSlots    TimeSlot[]
   bookings     Booking[]
   reviews      Review[]
+  services     MemberService[]
 
   @@map("member")
 }
@@ -159,8 +160,21 @@ model Service {
 
   organization Organization @relation(fields: [orgId], references: [id])
   bookings     Booking[]
+  members      MemberService[]
 
   @@map("service")
+}
+
+model MemberService {
+  memberId  String
+  serviceId String
+  createdAt DateTime @default(now())
+
+  member  Member  @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+
+  @@id([memberId, serviceId])
+  @@map("member_service")
 }
 
 // =============================================================

--- a/prisma/seed.test.ts
+++ b/prisma/seed.test.ts
@@ -2,6 +2,7 @@ import { BookingStatus, RewardStatus, Role } from '@/generated/prisma/client'
 import { describe, expect, it } from 'vitest'
 import {
   buildSeedBookings,
+  buildSeedMemberServices,
   buildSeedRewards,
   buildSeedTimeSlots,
   defaultSeedPassword,
@@ -31,6 +32,7 @@ describe('seed fixtures', () => {
       seedOrganization.id,
       ...Object.values(seedMembers).map((member) => member.id),
       ...Object.values(seedServices).map((service) => service.id),
+      ...buildSeedMemberServices().map(({ memberId, serviceId }) => `${memberId}:${serviceId}`),
       ...buildSeedTimeSlots().map((slot) => slot.id),
       ...buildSeedBookings().map((booking) => booking.id),
       ...buildSeedRewards().map((reward) => reward.id),
@@ -61,6 +63,16 @@ describe('seed fixtures', () => {
 
       expect(service).toBeDefined()
       expect(booking.totalPrice).toBe(service?.price)
+    }
+  })
+
+  it('associe chaque booking demo a un service propose par le membre', () => {
+    const memberServiceKeys = new Set(
+      buildSeedMemberServices().map(({ memberId, serviceId }) => `${memberId}:${serviceId}`),
+    )
+
+    for (const booking of buildSeedBookings()) {
+      expect(memberServiceKeys.has(`${booking.memberId}:${booking.serviceId}`)).toBe(true)
     }
   })
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -184,6 +184,23 @@ export function buildSeedBookings() {
   ]
 }
 
+export function buildSeedMemberServices() {
+  return [
+    {
+      memberId: seedMembers.mila.id,
+      serviceId: seedServices.cut.id,
+    },
+    {
+      memberId: seedMembers.mila.id,
+      serviceId: seedServices.color.id,
+    },
+    {
+      memberId: seedMembers.leo.id,
+      serviceId: seedServices.beard.id,
+    },
+  ]
+}
+
 export function buildSeedReviews() {
   return [
     {
@@ -255,6 +272,11 @@ async function clearSeedData(prisma: PrismaClient) {
     },
   })
   await prisma.reward.deleteMany({ where: { clientId: { in: userIds } } })
+  await prisma.memberService.deleteMany({
+    where: {
+      OR: [{ memberId: { in: memberIds } }, { serviceId: { in: serviceIds } }],
+    },
+  })
   await prisma.timeSlot.deleteMany({ where: { memberId: { in: memberIds } } })
   await prisma.service.deleteMany({ where: { id: { in: serviceIds } } })
   await prisma.member.deleteMany({ where: { id: { in: memberIds } } })
@@ -330,6 +352,7 @@ export async function runSeed() {
     })
 
     await prisma.timeSlot.createMany({ data: buildSeedTimeSlots() })
+    await prisma.memberService.createMany({ data: buildSeedMemberServices() })
     await prisma.booking.createMany({ data: buildSeedBookings() })
     await prisma.review.createMany({ data: buildSeedReviews() })
     await prisma.reward.createMany({ data: buildSeedRewards() })


### PR DESCRIPTION
## Resume
- Ajoute les routeurs tRPC metier `booking`, `service` et `timeSlot`.
- Ajoute l'association services/professionnels via `member_service`.
- Documente les routes tRPC pour faciliter le branchement UI.

## Changements
- `booking.confirm` et `booking.cancel`, avec `confirmPublic` garde en alias temporaire.
- CRUD services et creneaux avec controles owner/member.
- Association des services aux membres via `service.setMemberServices`.
- Flow public filtre les professionnels et les creneaux selon le service choisi.
- Seed, migration Prisma, tests d'integration et docs mis a jour.

## Commits
- `3ed55d3 feat: add trpc routes`
- `fe8785a feat: add member services`

## Points d'attention
- La migration `member_service` est incluse. La DB de dev locale a ete synchronisee avec `pnpm db:push` pour debloquer les tests.
- `.zed/` reste non suivi et n'est pas inclus dans la PR.

## Tests
- `pnpm typecheck` - OK
- `pnpm lint` - OK
- `pnpm test` - 19 tests OK
- `pnpm test:integration` - 34 tests OK
- `pnpm build:check` - OK