### PR TITLE
feat: owner services management

### DIFF
--- a/app/(protected)/member/layout.tsx
+++ b/app/(protected)/member/layout.tsx
@@ -4,11 +4,19 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { MemberSidebar } from '@/components/dashboard/member-sidebar'
 import { SiteHeader } from '@/components/site-header'
 import { requireMember } from '@/lib/auth'
+import { db } from '@/lib/db'
 
 export default async function MemberLayout({ children }: { children: ReactNode }) {
   // Garde l'espace pro + recupere la fiche Member. Memoise (cache) : la page
   // appelle aussi requireMember() sans relancer la requete.
   const { session } = await requireMember()
+
+  // Un member peut aussi etre proprietaire d'un salon -> on affiche alors le
+  // lien "Espace gerant". Etre owner = posseder une Organization (ownerId).
+  const ownedOrg = await db.organization.findUnique({
+    where: { ownerId: session.user.id },
+    select: { id: true },
+  })
 
   return (
     <SidebarProvider
@@ -21,6 +29,7 @@ export default async function MemberLayout({ children }: { children: ReactNode }
     >
       <MemberSidebar
         variant="inset"
+        isOwner={Boolean(ownedOrg)}
         user={{
           name: session.user.name,
           email: session.user.email,

--- a/app/(protected)/owner/layout.tsx
+++ b/app/(protected)/owner/layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
+import { OwnerSidebar } from '@/components/dashboard/owner-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { requireOwner } from '@/lib/auth'
+
+export default async function OwnerLayout({ children }: { children: ReactNode }) {
+  // Garde l'espace gérant : exige d'être propriétaire d'une orga (Organization.ownerId).
+  // Mémoïsé (cache) : la page peut rappeler requireOwner() sans relancer la requête.
+  const { session } = await requireOwner()
+
+  return (
+    <SidebarProvider
+      style={
+        {
+          '--sidebar-width': 'calc(var(--spacing) * 72)',
+          '--header-height': 'calc(var(--spacing) * 12)',
+        } as React.CSSProperties
+      }
+    >
+      <OwnerSidebar
+        variant="inset"
+        user={{
+          name: session.user.name,
+          email: session.user.email,
+          avatar: session.user.image ?? '',
+        }}
+      />
+      <SidebarInset>
+        <SiteHeader title="Espace gérant" />
+        <div className="flex flex-1 flex-col">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/app/(protected)/owner/loading.tsx
+++ b/app/(protected)/owner/loading.tsx
@@ -1,0 +1,31 @@
+// Skeleton de chargement — espace gérant (/owner)
+function Skeleton({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded-lg bg-black/[.06] ${className ?? ''}`} aria-hidden />
+  )
+}
+
+export default function OwnerLoading() {
+  return (
+    <div className="flex flex-col gap-8 p-6 lg:p-8" aria-label="Chargement…" aria-busy>
+      <section>
+        <Skeleton className="mb-2 h-7 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </section>
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-3 rounded-xl border border-black/[.06] bg-white p-6"
+          >
+            <div className="flex items-start justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="size-9 rounded-lg" />
+            </div>
+            <Skeleton className="h-8 w-12" />
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/app/(protected)/owner/page.tsx
+++ b/app/(protected)/owner/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+import { ArrowRight, CalendarCheck, Scissors, Users } from 'lucide-react'
+import { requireOwner } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { StatCard } from '@/components/dashboard/stat-card'
+
+export default async function OwnerDashboardPage() {
+  const { organization } = await requireOwner()
+
+  // Aperçu du salon : 3 compteurs en parallèle (services, pros, réservations).
+  const [servicesCount, membersCount, bookingsCount] = await Promise.all([
+    db.service.count({ where: { orgId: organization.id } }),
+    db.member.count({ where: { orgId: organization.id } }),
+    db.booking.count({ where: { member: { orgId: organization.id } } }),
+  ])
+
+  return (
+    <main className="flex flex-col gap-8 p-6 lg:p-8">
+      <section>
+        <h1 className="text-foreground text-2xl font-bold">{organization.name}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Pilotez votre salon : catalogue de services et professionnels.
+        </p>
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard title="Services" value={servicesCount} icon={Scissors} />
+        <StatCard title="Professionnels" value={membersCount} icon={Users} />
+        <StatCard title="Réservations" value={bookingsCount} icon={CalendarCheck} />
+      </section>
+
+      <section>
+        <Link
+          href="/owner/services"
+          className="bg-card hover:border-primary/40 group flex items-center justify-between rounded-xl border p-6 shadow-sm transition-colors"
+        >
+          <div>
+            <p className="text-foreground font-semibold">Gérer les services</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Créez vos prestations et choisissez quels professionnels les proposent.
+            </p>
+          </div>
+          <ArrowRight className="text-muted-foreground group-hover:text-primary size-5 shrink-0" />
+        </Link>
+      </section>
+    </main>
+  )
+}

--- a/app/(protected)/owner/services/page.tsx
+++ b/app/(protected)/owner/services/page.tsx
@@ -1,0 +1,9 @@
+import { requireOwner } from '@/lib/auth'
+import { OwnerServicesView } from '@/components/dashboard/owner-services-view'
+
+export default async function OwnerServicesPage() {
+  // requireOwner() : garde + récupère l'orga du propriétaire (déjà résolu par le layout, cache).
+  const { organization } = await requireOwner()
+
+  return <OwnerServicesView orgId={organization.id} />
+}

--- a/components/dashboard/member-services-view.tsx
+++ b/components/dashboard/member-services-view.tsx
@@ -2,6 +2,8 @@
 
 import { Scissors, Clock, Euro, Loader2 } from 'lucide-react'
 import { trpc } from '@/lib/trpc/client'
+import { formatPrice } from '@/lib/utils/format-price'
+import { formatDuration } from '@/lib/utils/format-duration'
 
 // ── Palette (identique au reste du dashboard membre) ─────────────────────────
 const C = {
@@ -11,18 +13,6 @@ const C = {
   card: '#ffffff',
   green: '#489B6E',
   greenBg: 'rgba(72,155,110,0.10)',
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-function formatPrice(price: number) {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(price)
-}
-
-function formatDuration(minutes: number) {
-  if (minutes < 60) return `${minutes} min`
-  const h = Math.floor(minutes / 60)
-  const m = minutes % 60
-  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`
 }
 
 // ── ServiceCard (lecture seule) ─────────────────────────────────────────────

--- a/components/dashboard/owner-services-view.tsx
+++ b/components/dashboard/owner-services-view.tsx
@@ -9,18 +9,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-function formatPrice(price: number) {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(price)
-}
-
-function formatDuration(minutes: number) {
-  if (minutes < 60) return `${minutes} min`
-  const h = Math.floor(minutes / 60)
-  const m = minutes % 60
-  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`
-}
+import { formatPrice } from '@/lib/utils/format-price'
+import { formatDuration } from '@/lib/utils/format-duration'
 
 // ── Types (alignés sur les selects de serviceRouter) ─────────────────────────
 interface OrgMember {

--- a/components/dashboard/owner-services-view.tsx
+++ b/components/dashboard/owner-services-view.tsx
@@ -1,0 +1,421 @@
+'use client'
+
+import { useState } from 'react'
+import { Clock, Euro, Loader2, Pencil, Plus, Trash2, Users, X } from 'lucide-react'
+import { trpc } from '@/lib/trpc/client'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Badge } from '@/components/ui/badge'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function formatPrice(price: number) {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(price)
+}
+
+function formatDuration(minutes: number) {
+  if (minutes < 60) return `${minutes} min`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`
+}
+
+// ── Types (alignés sur les selects de serviceRouter) ─────────────────────────
+interface OrgMember {
+  id: string
+  user: { name: string; image: string | null }
+}
+
+interface ServiceItem {
+  id: string
+  name: string
+  description: string | null
+  duration: number
+  price: number
+  members: { memberId: string }[]
+}
+
+// ── Formulaire création / édition ───────────────────────────────────────────
+interface ServiceFormValues {
+  name: string
+  description: string
+  duration: string
+  price: string
+}
+
+function ServiceForm({
+  initial,
+  pending,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: Partial<ServiceFormValues>
+  pending: boolean
+  submitLabel: string
+  onSubmit: (values: {
+    name: string
+    description?: string
+    duration: number
+    price: number
+  }) => void
+  onCancel?: () => void
+}) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [description, setDescription] = useState(initial?.description ?? '')
+  const [duration, setDuration] = useState(initial?.duration ?? '')
+  const [price, setPrice] = useState(initial?.price ?? '')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const durationNum = parseInt(duration, 10)
+    const priceNum = parseFloat(price.replace(',', '.'))
+
+    if (name.trim().length < 2) return toast.error('Le nom doit faire au moins 2 caractères.')
+    if (isNaN(durationNum) || durationNum < 5) return toast.error('Durée invalide (min 5 min).')
+    if (isNaN(priceNum) || priceNum < 0) return toast.error('Prix invalide.')
+
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      duration: durationNum,
+      price: priceNum,
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="grid gap-1.5">
+        <Label htmlFor="svc-name">
+          Nom du service <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="svc-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Ex : Coupe femme, Soin visage…"
+          maxLength={80}
+        />
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label htmlFor="svc-desc">
+          Description <span className="text-muted-foreground text-xs">(optionnel)</span>
+        </Label>
+        <Input
+          id="svc-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Courte description…"
+          maxLength={500}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-1.5">
+          <Label htmlFor="svc-duration">
+            Durée (min) <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="svc-duration"
+            type="number"
+            min={5}
+            max={480}
+            step={5}
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            placeholder="30"
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="svc-price">
+            Prix (€) <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="svc-price"
+            type="number"
+            min={0}
+            max={10000}
+            step={0.5}
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            placeholder="25"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          {submitLabel}
+        </Button>
+        {onCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={pending}>
+            Annuler
+          </Button>
+        )}
+      </div>
+    </form>
+  )
+}
+
+// ── Panneau d'assignation des pros à un service ──────────────────────────────
+function AssignPanel({
+  service,
+  members,
+  onClose,
+}: {
+  service: ServiceItem
+  members: OrgMember[]
+  onClose: () => void
+}) {
+  const utils = trpc.useUtils()
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(service.members.map((m) => m.memberId)),
+  )
+
+  const setServiceMembers = trpc.service.setServiceMembers.useMutation({
+    onSuccess() {
+      toast.success('Professionnels mis à jour')
+      utils.service.listByOrganization.invalidate()
+      onClose()
+    },
+    onError(e) {
+      toast.error(e.message)
+    },
+  })
+
+  function toggle(memberId: string, checked: boolean) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(memberId)
+      else next.delete(memberId)
+      return next
+    })
+  }
+
+  return (
+    <div className="bg-muted/40 mt-3 rounded-lg border p-4">
+      <p className="text-foreground mb-3 text-sm font-medium">Qui propose « {service.name} » ?</p>
+
+      {members.length === 0 ? (
+        <p className="text-muted-foreground text-sm">Aucun professionnel dans le salon.</p>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {members.map((member) => (
+            <label key={member.id} className="flex cursor-pointer items-center gap-2.5 text-sm">
+              <Checkbox
+                checked={selected.has(member.id)}
+                onCheckedChange={(c) => toggle(member.id, c === true)}
+              />
+              <span className="text-foreground">{member.user.name}</span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex gap-2">
+        <Button
+          size="sm"
+          disabled={setServiceMembers.isPending}
+          onClick={() =>
+            setServiceMembers.mutate({ serviceId: service.id, memberIds: [...selected] })
+          }
+        >
+          {setServiceMembers.isPending && <Loader2 className="size-4 animate-spin" />}
+          Enregistrer
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onClose} disabled={setServiceMembers.isPending}>
+          Annuler
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ── Carte d'un service (affichage + édition + assignation) ───────────────────
+function ServiceRow({ service, members }: { service: ServiceItem; members: OrgMember[] }) {
+  const utils = trpc.useUtils()
+  const [mode, setMode] = useState<'view' | 'edit' | 'assign'>('view')
+
+  const assignedNames = members
+    .filter((m) => service.members.some((sm) => sm.memberId === m.id))
+    .map((m) => m.user.name)
+
+  const update = trpc.service.update.useMutation({
+    onSuccess() {
+      toast.success('Service mis à jour')
+      utils.service.listByOrganization.invalidate()
+      setMode('view')
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  const remove = trpc.service.delete.useMutation({
+    onSuccess() {
+      toast.success('Service supprimé')
+      utils.service.listByOrganization.invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  return (
+    <article className="bg-card rounded-xl border p-4 shadow-sm">
+      {mode === 'edit' ? (
+        <ServiceForm
+          initial={{
+            name: service.name,
+            description: service.description ?? '',
+            duration: String(service.duration),
+            price: String(service.price),
+          }}
+          pending={update.isPending}
+          submitLabel="Enregistrer"
+          onSubmit={(values) => update.mutate({ serviceId: service.id, ...values })}
+          onCancel={() => setMode('view')}
+        />
+      ) : (
+        <>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-foreground font-semibold">{service.name}</p>
+              {service.description && (
+                <p className="text-muted-foreground mt-0.5 truncate text-sm">
+                  {service.description}
+                </p>
+              )}
+              <div className="text-muted-foreground mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                <span className="flex items-center gap-1">
+                  <Clock className="size-3.5" />
+                  {formatDuration(service.duration)}
+                </span>
+                <span className="text-primary flex items-center gap-1 font-medium">
+                  <Euro className="size-3.5" />
+                  {formatPrice(service.price)}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex shrink-0 gap-1">
+              <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Assigner des professionnels"
+                onClick={() => setMode(mode === 'assign' ? 'view' : 'assign')}
+              >
+                <Users className="size-4" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Modifier le service"
+                onClick={() => setMode('edit')}
+              >
+                <Pencil className="size-4" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="text-destructive hover:text-destructive"
+                aria-label="Supprimer le service"
+                disabled={remove.isPending}
+                onClick={() => remove.mutate({ serviceId: service.id })}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Pros assignés */}
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {assignedNames.length === 0 ? (
+              <span className="text-muted-foreground text-xs">Aucun pro assigné</span>
+            ) : (
+              assignedNames.map((name) => (
+                <Badge key={name} variant="secondary">
+                  {name}
+                </Badge>
+              ))
+            )}
+          </div>
+
+          {mode === 'assign' && (
+            <AssignPanel service={service} members={members} onClose={() => setMode('view')} />
+          )}
+        </>
+      )}
+    </article>
+  )
+}
+
+// ── Vue principale ───────────────────────────────────────────────────────────
+export function OwnerServicesView({ orgId }: { orgId: string }) {
+  const utils = trpc.useUtils()
+  const [showCreate, setShowCreate] = useState(false)
+
+  const servicesQuery = trpc.service.listByOrganization.useQuery({ orgId })
+  const membersQuery = trpc.service.listOrgMembers.useQuery({ orgId })
+
+  const create = trpc.service.create.useMutation({
+    onSuccess() {
+      toast.success('Service créé')
+      utils.service.listByOrganization.invalidate()
+      setShowCreate(false)
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  const services = servicesQuery.data ?? []
+  const members = membersQuery.data ?? []
+
+  return (
+    <main className="flex w-full max-w-3xl flex-col gap-6 p-6 lg:p-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-foreground text-2xl font-bold">Services</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Gérez le catalogue du salon et choisissez quels professionnels proposent chaque service.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate((v) => !v)} variant={showCreate ? 'ghost' : 'default'}>
+          {showCreate ? <X className="size-4" /> : <Plus className="size-4" />}
+          {showCreate ? 'Fermer' : 'Nouveau service'}
+        </Button>
+      </div>
+
+      {showCreate && (
+        <section className="bg-card rounded-xl border p-5 shadow-sm">
+          <h2 className="text-foreground mb-4 font-semibold">Nouveau service</h2>
+          <ServiceForm
+            pending={create.isPending}
+            submitLabel="Créer le service"
+            onSubmit={(values) => create.mutate({ orgId, ...values })}
+            onCancel={() => setShowCreate(false)}
+          />
+        </section>
+      )}
+
+      <section className="flex flex-col gap-3">
+        {servicesQuery.isLoading ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Loader2 className="size-4 animate-spin" />
+            Chargement…
+          </div>
+        ) : services.length === 0 ? (
+          <div className="bg-muted/40 rounded-xl border border-dashed p-8 text-center">
+            <p className="text-foreground font-semibold">Aucun service pour l&apos;instant</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Créez votre premier service pour qu&apos;il apparaisse dans les réservations.
+            </p>
+          </div>
+        ) : (
+          services.map((service) => (
+            <ServiceRow key={service.id} service={service} members={members} />
+          ))
+        )}
+      </section>
+    </main>
+  )
+}

--- a/components/dashboard/owner-sidebar.tsx
+++ b/components/dashboard/owner-sidebar.tsx
@@ -1,16 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import {
-  LayoutDashboard,
-  CalendarDays,
-  Clock,
-  Tag,
-  Store,
-  User,
-  Scissors,
-  ArrowLeftRight,
-} from 'lucide-react'
+import { LayoutDashboard, Scissors, Tag, ArrowLeftRight, UserRound } from 'lucide-react'
 import Link from 'next/link'
 import { NavMain } from '@/components/nav-main'
 import { NavUser } from '@/components/nav-user'
@@ -27,26 +18,22 @@ import {
 } from '@/components/ui/sidebar'
 
 const navMain = [
-  { title: 'Tableau de bord', url: '/member', icon: <LayoutDashboard /> },
-  { title: 'Mon calendrier', url: '/member/calendar', icon: <CalendarDays /> },
-  { title: 'Mes créneaux', url: '/member/availability', icon: <Clock /> },
-  { title: 'Mes services', url: '/member/services', icon: <Tag /> },
-  { title: 'Mon profil', url: '/member/profile', icon: <User /> },
+  { title: 'Tableau de bord', url: '/owner', icon: <LayoutDashboard /> },
+  { title: 'Services', url: '/owner/services', icon: <Tag /> },
 ]
 
-interface MemberSidebarProps extends React.ComponentProps<typeof Sidebar> {
+interface OwnerSidebarProps extends React.ComponentProps<typeof Sidebar> {
   user: { name: string; email: string; avatar: string }
-  isOwner?: boolean
 }
 
-export function MemberSidebar({ user, isOwner, ...props }: MemberSidebarProps) {
+export function OwnerSidebar({ user, ...props }: OwnerSidebarProps) {
   return (
     <Sidebar collapsible="offcanvas" {...props}>
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:p-1.5!">
-              <Link href="/member" className="flex items-center gap-2">
+              <Link href="/owner" className="flex items-center gap-2">
                 <span
                   className="flex size-6 items-center justify-center rounded-md"
                   style={{ background: '#489B6E' }}
@@ -54,7 +41,7 @@ export function MemberSidebar({ user, isOwner, ...props }: MemberSidebarProps) {
                   <Scissors size={13} className="rotate-90 text-white" />
                 </span>
                 <span className="text-base font-bold" style={{ color: '#253122' }}>
-                  CutBook <span className="text-xs font-normal opacity-50">Pro</span>
+                  CutBook <span className="text-xs font-normal opacity-50">Gérant</span>
                 </span>
               </Link>
             </SidebarMenuButton>
@@ -65,20 +52,18 @@ export function MemberSidebar({ user, isOwner, ...props }: MemberSidebarProps) {
       <SidebarContent>
         <NavMain items={navMain} />
 
-        {/* Bascule vers la vue client (un member est aussi un client) */}
+        {/* Bascule vers les autres espaces (un gérant est aussi pro et client) */}
         <SidebarGroup className="mt-auto">
           <SidebarGroupContent>
             <SidebarMenu>
-              {isOwner && (
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild tooltip="Espace gérant">
-                    <Link href="/owner">
-                      <Store />
-                      <span>Espace gérant</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              )}
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild tooltip="Espace professionnel">
+                  <Link href="/member">
+                    <UserRound />
+                    <span>Espace pro</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild tooltip="Vue client">
                   <Link href="/client">

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -27,7 +27,8 @@ export function NavMain({
         <SidebarMenu>
           {items.map((item) => {
             // Les URL racines ne sont actives que sur une correspondance exacte
-            const isDashboardRoot = item.url === '/admin' || item.url === '/member'
+            const isDashboardRoot =
+              item.url === '/admin' || item.url === '/member' || item.url === '/owner'
             const isActive = isDashboardRoot
               ? pathname === item.url
               : pathname === item.url || pathname.startsWith(item.url + '/')

--- a/lib/services/schema.test.ts
+++ b/lib/services/schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { serviceInputSchema, updateServiceSchema, setServiceMembersSchema } from './schema'
+
+const validInput = {
+  orgId: 'org_1',
+  name: 'Coupe femme',
+  description: 'Shampoing + coupe',
+  duration: 30,
+  price: 25,
+}
+
+describe('serviceInputSchema', () => {
+  it('accepte une création valide', () => {
+    expect(serviceInputSchema.safeParse(validInput).success).toBe(true)
+  })
+
+  it('accepte une description nulle et des memberIds optionnels', () => {
+    const result = serviceInputSchema.safeParse({
+      ...validInput,
+      description: null,
+      memberIds: ['m1', 'm2'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('refuse un nom trop court', () => {
+    expect(serviceInputSchema.safeParse({ ...validInput, name: 'A' }).success).toBe(false)
+  })
+
+  it('refuse une durée non entière ou sous le minimum', () => {
+    expect(serviceInputSchema.safeParse({ ...validInput, duration: 30.5 }).success).toBe(false)
+    expect(serviceInputSchema.safeParse({ ...validInput, duration: 4 }).success).toBe(false)
+  })
+
+  it('refuse un prix négatif ou hors plage', () => {
+    expect(serviceInputSchema.safeParse({ ...validInput, price: -1 }).success).toBe(false)
+    expect(serviceInputSchema.safeParse({ ...validInput, price: 10_001 }).success).toBe(false)
+  })
+
+  it('refuse un orgId vide', () => {
+    expect(serviceInputSchema.safeParse({ ...validInput, orgId: '' }).success).toBe(false)
+  })
+})
+
+describe('updateServiceSchema', () => {
+  it('accepte une mise à jour partielle (un seul champ)', () => {
+    expect(updateServiceSchema.safeParse({ serviceId: 's1', price: 30 }).success).toBe(true)
+  })
+
+  it('refuse une mise à jour sans aucun champ à modifier', () => {
+    expect(updateServiceSchema.safeParse({ serviceId: 's1' }).success).toBe(false)
+  })
+
+  it('refuse une valeur invalide même en partiel', () => {
+    expect(updateServiceSchema.safeParse({ serviceId: 's1', duration: 1 }).success).toBe(false)
+  })
+})
+
+describe('setServiceMembersSchema', () => {
+  it('accepte une liste de pros', () => {
+    expect(
+      setServiceMembersSchema.safeParse({ serviceId: 's1', memberIds: ['m1', 'm2'] }).success,
+    ).toBe(true)
+  })
+
+  it('accepte une liste vide (retirer tous les pros)', () => {
+    expect(setServiceMembersSchema.safeParse({ serviceId: 's1', memberIds: [] }).success).toBe(true)
+  })
+
+  it('refuse un serviceId manquant', () => {
+    expect(setServiceMembersSchema.safeParse({ memberIds: ['m1'] }).success).toBe(false)
+  })
+})

--- a/lib/services/schema.ts
+++ b/lib/services/schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+// Schemas Zod du domaine "service", partages entre le router tRPC (validation
+// serveur) et les formulaires owner. Extraits du router pour etre testables en
+// isolation (unit tests) et eviter la duplication des contraintes.
+
+// Champs metier d'un service (nom, description, duree, prix).
+export const serviceFieldsSchema = z.object({
+  name: z.string().min(2).max(80),
+  description: z.string().max(500).nullable().optional(),
+  duration: z.number().int().min(5).max(480),
+  price: z.number().min(0).max(10_000),
+})
+
+// Creation : champs metier + rattachement orga + assignation optionnelle de pros.
+export const serviceInputSchema = serviceFieldsSchema.extend({
+  orgId: z.string().min(1),
+  memberIds: z.array(z.string().min(1)).optional(),
+})
+
+// Mise a jour : tous les champs optionnels, mais au moins un doit etre renseigne.
+export const updateServiceSchema = serviceFieldsSchema
+  .partial()
+  .extend({
+    serviceId: z.string().min(1),
+  })
+  .refine(
+    ({ name, description, duration, price }) =>
+      name !== undefined ||
+      description !== undefined ||
+      duration !== undefined ||
+      price !== undefined,
+    'Au moins un champ doit etre renseigne.',
+  )
+
+// Assignation par service : la liste (potentiellement vide) des pros qui le proposent.
+export const setServiceMembersSchema = z.object({
+  serviceId: z.string().min(1),
+  memberIds: z.array(z.string().min(1)),
+})

--- a/lib/trpc/routers/service.ts
+++ b/lib/trpc/routers/service.ts
@@ -219,6 +219,28 @@ export const serviceRouter = router({
       })
     }),
 
+  // Liste tous les professionnels du salon (pour l'UI d'assignation owner).
+  // Accessible aux membres du salon + owner (meme garde que listByOrganization).
+  listOrgMembers: protectedProcedure
+    .input(z.object({ orgId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      await ensureOrgAccess(ctx, input.orgId)
+
+      return await ctx.db.member.findMany({
+        where: { orgId: input.orgId },
+        select: {
+          id: true,
+          user: {
+            select: {
+              name: true,
+              image: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+      })
+    }),
+
   create: protectedProcedure.input(serviceInputSchema).mutation(async ({ ctx, input }) => {
     await ensureOrgOwner(ctx, input.orgId)
     await ensureMembersBelongToOrg(ctx, {
@@ -316,6 +338,45 @@ export const serviceRouter = router({
       return {
         memberId: member.id,
         serviceIds,
+      }
+    }),
+
+  // Assignation PAR SERVICE : fixe la liste des pros qui proposent un service.
+  // Miroir de setMemberServices, cote owner uniquement (getServiceForOwner garde).
+  setServiceMembers: protectedProcedure
+    .input(
+      z.object({
+        serviceId: z.string().min(1),
+        memberIds: z.array(z.string().min(1)),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const service = await getServiceForOwner(ctx, input.serviceId)
+      const memberIds = [...new Set(input.memberIds)]
+
+      await ensureMembersBelongToOrg(ctx, {
+        orgId: service.orgId,
+        memberIds,
+      })
+
+      await ctx.db.$transaction(async (tx) => {
+        await tx.memberService.deleteMany({
+          where: { serviceId: service.id },
+        })
+
+        if (memberIds.length > 0) {
+          await tx.memberService.createMany({
+            data: memberIds.map((memberId) => ({
+              memberId,
+              serviceId: service.id,
+            })),
+          })
+        }
+      })
+
+      return {
+        serviceId: service.id,
+        memberIds,
       }
     }),
 })

--- a/lib/trpc/routers/service.ts
+++ b/lib/trpc/routers/service.ts
@@ -2,30 +2,11 @@
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { protectedProcedure, router } from '../init'
-
-const serviceInputSchema = z.object({
-  orgId: z.string().min(1),
-  name: z.string().min(2).max(80),
-  description: z.string().max(500).nullable().optional(),
-  duration: z.number().int().min(5).max(480),
-  price: z.number().min(0).max(10_000),
-  memberIds: z.array(z.string().min(1)).optional(),
-})
-
-const updateServiceSchema = serviceInputSchema
-  .omit({ orgId: true, memberIds: true })
-  .partial()
-  .extend({
-    serviceId: z.string().min(1),
-  })
-  .refine(
-    ({ name, description, duration, price }) =>
-      name !== undefined ||
-      description !== undefined ||
-      duration !== undefined ||
-      price !== undefined,
-    'Au moins un champ doit etre renseigne.',
-  )
+import {
+  serviceInputSchema,
+  updateServiceSchema,
+  setServiceMembersSchema,
+} from '@/lib/services/schema'
 
 async function ensureOrgAccess(
   ctx: { db: typeof import('@/lib/db').db; user: { id: string } },
@@ -344,12 +325,7 @@ export const serviceRouter = router({
   // Assignation PAR SERVICE : fixe la liste des pros qui proposent un service.
   // Miroir de setMemberServices, cote owner uniquement (getServiceForOwner garde).
   setServiceMembers: protectedProcedure
-    .input(
-      z.object({
-        serviceId: z.string().min(1),
-        memberIds: z.array(z.string().min(1)),
-      }),
-    )
+    .input(setServiceMembersSchema)
     .mutation(async ({ ctx, input }) => {
       const service = await getServiceForOwner(ctx, input.serviceId)
       const memberIds = [...new Set(input.memberIds)]

--- a/lib/utils/format-duration.test.ts
+++ b/lib/utils/format-duration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatDuration } from './format-duration'
+
+describe('formatDuration', () => {
+  it('affiche les durees sous une heure en minutes', () => {
+    expect(formatDuration(5)).toBe('5 min')
+    expect(formatDuration(30)).toBe('30 min')
+    expect(formatDuration(45)).toBe('45 min')
+  })
+
+  it('affiche une heure pile sans minutes', () => {
+    expect(formatDuration(60)).toBe('1h')
+    expect(formatDuration(120)).toBe('2h')
+  })
+
+  it('affiche les heures + minutes avec padding sur 2 chiffres', () => {
+    expect(formatDuration(90)).toBe('1h30')
+    expect(formatDuration(125)).toBe('2h05')
+    expect(formatDuration(135)).toBe('2h15')
+  })
+})

--- a/lib/utils/format-duration.ts
+++ b/lib/utils/format-duration.ts
@@ -1,0 +1,11 @@
+/**
+ * Formate une duree en minutes pour l'affichage humain.
+ * Ex : 30 -> "30 min", 60 -> "1h", 90 -> "1h30", 125 -> "2h05".
+ * Utilise par les vues services (membre + gerant).
+ */
+export function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`
+}

--- a/lib/utils/format-price.test.ts
+++ b/lib/utils/format-price.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatPrice } from './format-price'
+
+// On normalise les espaces : fr-FR insere des espaces insecables (U+202F / U+00A0)
+// devant € et comme separateur de milliers, ce qui rend l'assertion brute fragile.
+const strip = (value: string) => value.replace(/\s/g, '')
+
+describe('formatPrice', () => {
+  it('formate un entier avec deux decimales et le symbole euro', () => {
+    expect(strip(formatPrice(25))).toBe('25,00€')
+  })
+
+  it('formate zero', () => {
+    expect(strip(formatPrice(0))).toBe('0,00€')
+  })
+
+  it('formate un prix decimal', () => {
+    expect(strip(formatPrice(9.9))).toBe('9,90€')
+  })
+
+  it('insere un separateur de milliers', () => {
+    // 1234.5 -> "1 234,50 €" (espaces retires par strip)
+    expect(strip(formatPrice(1234.5))).toBe('1234,50€')
+  })
+
+  it('utilise la virgule comme separateur decimal (locale fr)', () => {
+    expect(formatPrice(12.34)).toContain('12,34')
+  })
+})

--- a/lib/utils/format-price.ts
+++ b/lib/utils/format-price.ts
@@ -1,0 +1,7 @@
+/**
+ * Formate un prix en euros selon la locale francaise.
+ * Ex : 25 -> "25,00 €". Utilise par les vues services (membre + gerant).
+ */
+export function formatPrice(price: number): string {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(price)
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,7 @@ import { getSessionCookie } from 'better-auth/cookies'
 // Proxy = garde UX optimiste uniquement. Les vraies autorisations (rôles) restent
 // cote serveur : requireAdmin() / requireSession() dans les layouts protégés.
 // Ici on ne décide QUE "a un cookie de session -> laisse passer, sinon -> /login".
-const protectedRoutes = ['/admin', '/client', '/member']
+const protectedRoutes = ['/admin', '/client', '/member', '/owner']
 const authRoutes = ['/login', '/register']
 
 function isRoute(pathname: string, routes: string[]) {
@@ -52,6 +52,8 @@ export const config = {
     '/client/:path*',
     '/member',
     '/member/:path*',
+    '/owner',
+    '/owner/:path*',
     '/login',
     '/register',
   ],


### PR DESCRIPTION
## Quoi

Espace gérant (owner) : gestion du catalogue de services + assignation des pros par service. Ferme la boucle où `/member/services` restait vide faute d'UI d'assignation.

## Pages

- `/owner` — tableau de bord (compteurs services / pros / réservations)
- `/owner/services` — CRUD catalogue + assignation des pros (checkboxes par service)
- Lien « Espace gérant » dans la sidebar pro (visible seulement si on possède un salon)

## tRPC

- `service.listOrgMembers` — liste les pros de l'orga
- `service.setServiceMembers` — set des assignations (transaction: deleteMany + createMany), guard owner + vérif appartenance orga
- Schemas Zod extraits dans `lib/services/schema.ts`

## Tests

- Unit : `lib/services/schema.test.ts`, `lib/utils/format-price.test.ts`, `lib/utils/format-duration.test.ts`
- 39 unit + 34 integration au vert

## Notes

- `member-services-view` repassé en lecture seule (l'assignation est désormais côté owner)
- Utils `format-price` / `format-duration` extraits et réutilisés des deux côtés