### PR TITLE
feat: public booking slots trpc

### DIFF
--- a/app/(public)/[org-slug]/booking/slot/page.tsx
+++ b/app/(public)/[org-slug]/booking/slot/page.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
-import { PublicSlotPicker } from '@/components/booking/public-slot-picker'
+import { PublicSlotPickerLive } from '@/components/booking/public-slot-picker-live'
 import { getPublicOrgBookingHref } from '@/lib/routes/organization-public-route'
-import {
-  listPublicOrganizationAvailableSlots,
-  listPublicSlotDates,
-} from '@/lib/organizations/public-organization'
+import { getPublicBookingSlots } from '@/lib/organizations/public-organization'
 
 interface Props {
   params: Promise<{ 'org-slug': string }>
@@ -20,19 +17,12 @@ export const metadata: Metadata = {
 export default async function PublicBookingSlotPage({ params, searchParams }: Props) {
   const { 'org-slug': orgSlug } = await params
   const { service, member } = await searchParams
-  const slots = await listPublicOrganizationAvailableSlots(orgSlug, {
+
+  // Fetch SSR : sert d'initialData au wrapper tRPC (rendu instantané + SEO).
+  const initialData = await getPublicBookingSlots(orgSlug, {
     memberId: member,
     serviceId: service,
   })
-  const slotDates = listPublicSlotDates(slots)
-  const publicSlots = slots.map((slot) => ({
-    id: slot.id,
-    dateKey: slot.date.toISOString().slice(0, 10),
-    startTime: slot.startTime,
-    endTime: slot.endTime,
-    isAvailable: slot.isAvailable,
-    memberName: slot.member.user.name,
-  }))
 
   return (
     <main className="mx-auto w-full max-w-3xl space-y-8 px-4 py-6">
@@ -50,12 +40,11 @@ export default async function PublicBookingSlotPage({ params, searchParams }: Pr
         </h1>
       </div>
 
-      <PublicSlotPicker
+      <PublicSlotPickerLive
         orgSlug={orgSlug}
         serviceId={service}
         memberId={member}
-        dates={slotDates}
-        slots={publicSlots}
+        initialData={initialData}
       />
     </main>
   )

--- a/components/booking/confirm-booking-form.test.tsx
+++ b/components/booking/confirm-booking-form.test.tsx
@@ -7,6 +7,13 @@ const { routerReplace } = vi.hoisted(() => ({
 
 vi.mock('@/lib/trpc/client', () => ({
   trpc: {
+    useUtils: () => ({
+      booking: {
+        publicSlots: {
+          invalidate: vi.fn(),
+        },
+      },
+    }),
     booking: {
       confirmPublic: {
         useMutation: (options: {

--- a/components/booking/confirm-booking-form.tsx
+++ b/components/booking/confirm-booking-form.tsx
@@ -23,6 +23,7 @@ export function ConfirmBookingForm({
   const [isConfirmed, setIsConfirmed] = useState(false)
   const [optimisticConfirming, setOptimisticConfirming] = useState(false)
   const router = useRouter()
+  const utils = trpc.useUtils()
 
   useEffect(() => {
     if (!isConfirmed) {
@@ -41,6 +42,9 @@ export function ConfirmBookingForm({
       setOptimisticConfirming(false)
       setIsConfirmed(true)
       setMessage('Reservation confirmee.')
+      // Le créneau réservé n'est plus dispo : on invalide la liste pour CE client
+      // (utile s'il revient en arrière sur la page de sélection).
+      void utils.booking.publicSlots.invalidate()
     },
     onError(error) {
       setOptimisticConfirming(false)

--- a/components/booking/public-slot-picker-live.tsx
+++ b/components/booking/public-slot-picker-live.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { trpc } from '@/lib/trpc/client'
+import type { getPublicBookingSlots } from '@/lib/organizations/public-organization'
+import { PublicSlotPicker } from './public-slot-picker'
+
+// Type des données partagé avec la source serveur (import type -> aucun code serveur bundlé).
+type PublicBookingSlots = Awaited<ReturnType<typeof getPublicBookingSlots>>
+
+interface PublicSlotPickerLiveProps {
+  orgSlug: string
+  serviceId?: string
+  memberId?: string
+  initialData: PublicBookingSlots
+}
+
+/**
+ * Wrapper client : alimente le PublicSlotPicker (présentationnel) via une query tRPC cachée.
+ *
+ * - `initialData` : rendu SSR instantané (SEO + zéro flash de chargement).
+ * - `refetchOnWindowFocus` + `refetchInterval` : c'est le SEUL moyen pour qu'un client voie
+ *   les disponibilités mises à jour par le pro. L'invalidation TanStack Query ne traverse pas
+ *   les sessions/navigateurs — le client doit re-lire la BDD (focus ou polling léger).
+ */
+export function PublicSlotPickerLive({
+  orgSlug,
+  serviceId,
+  memberId,
+  initialData,
+}: PublicSlotPickerLiveProps) {
+  const { data } = trpc.booking.publicSlots.useQuery(
+    { orgSlug, serviceId, memberId },
+    {
+      initialData,
+      // staleTime 0 : override du défaut global (60s) pour que CHAQUE retour sur l'onglet
+      // (focus) déclenche un refetch -> le client voit aussitôt les dispos ajoutées par le pro.
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      refetchInterval: 10_000, // filet : poll toutes les 10s tant que l'onglet est actif
+    },
+  )
+
+  return (
+    <PublicSlotPicker
+      orgSlug={orgSlug}
+      serviceId={serviceId}
+      memberId={memberId}
+      dates={data.dates}
+      slots={data.slots}
+    />
+  )
+}

--- a/lib/organizations/public-booking-slot.test.ts
+++ b/lib/organizations/public-booking-slot.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { toPublicBookingSlot } from './public-booking-slot'
+
+describe('toPublicBookingSlot', () => {
+  it('mappe un créneau brut vers la forme publique attendue', () => {
+    const result = toPublicBookingSlot({
+      id: 'slot-1',
+      date: new Date('2026-05-12T00:00:00.000Z'),
+      startTime: '10:30',
+      endTime: '11:30',
+      isAvailable: true,
+      member: { user: { name: 'Mila Laurent' } },
+    })
+
+    expect(result).toEqual({
+      id: 'slot-1',
+      dateKey: '2026-05-12',
+      startTime: '10:30',
+      endTime: '11:30',
+      isAvailable: true,
+      memberName: 'Mila Laurent',
+    })
+  })
+
+  it('dérive dateKey en YYYY-MM-DD et conserve indisponibilité + nom du pro', () => {
+    const result = toPublicBookingSlot({
+      id: 'slot-2',
+      date: new Date('2026-12-01T23:59:59.000Z'),
+      startTime: '09:00',
+      endTime: '09:45',
+      isAvailable: false,
+      member: { user: { name: 'Leo Martin' } },
+    })
+
+    expect(result.dateKey).toBe('2026-12-01')
+    expect(result.isAvailable).toBe(false)
+    expect(result.memberName).toBe('Leo Martin')
+  })
+})

--- a/lib/organizations/public-booking-slot.ts
+++ b/lib/organizations/public-booking-slot.ts
@@ -1,0 +1,33 @@
+// Mapping pur : créneau brut (Prisma) -> forme publique consommée par l'UI de réservation.
+// Isolé dans son propre fichier (sans import de `db`) pour rester testable en unit, sans BDD.
+
+interface RawBookingSlot {
+  id: string
+  date: Date
+  startTime: string
+  endTime: string
+  isAvailable: boolean
+  member: { user: { name: string } }
+}
+
+export interface PublicBookingSlot {
+  id: string
+  dateKey: string
+  startTime: string
+  endTime: string
+  isAvailable: boolean
+  memberName: string
+}
+
+// `dateKey` au format "YYYY-MM-DD" : clé de regroupement par jour côté UI,
+// identique à celle dérivée par listPublicSlotDates (cohérence date <-> créneaux).
+export function toPublicBookingSlot(slot: RawBookingSlot): PublicBookingSlot {
+  return {
+    id: slot.id,
+    dateKey: slot.date.toISOString().slice(0, 10),
+    startTime: slot.startTime,
+    endTime: slot.endTime,
+    isAvailable: slot.isAvailable,
+    memberName: slot.member.user.name,
+  }
+}

--- a/lib/organizations/public-organization.ts
+++ b/lib/organizations/public-organization.ts
@@ -1,6 +1,9 @@
 import { db } from '@/lib/db'
 import { normalizePublicOrgSlug } from '@/lib/routes/organization-public-route'
-export { listPublicSlotDates } from './public-slot-dates'
+import { listPublicSlotDates } from './public-slot-dates'
+import { toPublicBookingSlot } from './public-booking-slot'
+
+export { listPublicSlotDates }
 
 export async function listPublicOrganizations() {
   return await db.organization.findMany({
@@ -133,6 +136,20 @@ export async function listPublicOrganizationAvailableSlots(
   }
 
   return virtualSlots
+}
+
+// Forme prête pour l'UI publique (créneaux mappés + dates dérivées).
+// Source unique partagée par le SSR (initialData) et la procédure tRPC booking.publicSlots.
+export async function getPublicBookingSlots(
+  orgSlug: string,
+  filters: PublicOrganizationSlotFilters = {},
+) {
+  const slots = await listPublicOrganizationAvailableSlots(orgSlug, filters)
+
+  return {
+    slots: slots.map(toPublicBookingSlot),
+    dates: listPublicSlotDates(slots),
+  }
 }
 
 interface PublicBookingConfirmationInput {

--- a/lib/trpc/routers/booking.integration.test.ts
+++ b/lib/trpc/routers/booking.integration.test.ts
@@ -39,6 +39,49 @@ describe('bookingRouter', () => {
     })
   }
 
+  // Caller public (sans session) : la page de réservation est accessible sans login.
+  const publicCaller = appRouter.createCaller({ db, session: null, user: null })
+
+  const slotDurationMinutes = (slot: { startTime: string; endTime: string }) => {
+    const toMins = (t: string) => {
+      const [h, m] = t.split(':').map(Number)
+      return (h || 0) * 60 + (m || 0)
+    }
+    return toMins(slot.endTime) - toMins(slot.startTime)
+  }
+
+  it('expose les creneaux publics filtres par membre et service', async () => {
+    const result = await publicCaller.booking.publicSlots({
+      orgSlug: seedOrganization.slug,
+      memberId: seedMembers.mila.id,
+      serviceId: seedServices.cut.id,
+    })
+
+    expect(result.slots.length).toBeGreaterThan(0)
+    // Tous les creneaux renvoyes sont libres (le creneau deja reserve est exclu).
+    expect(result.slots.every((slot) => slot.isAvailable)).toBe(true)
+    expect(result.slots.every((slot) => slot.memberName === 'Mila Laurent')).toBe(true)
+    // Sous-creneaux generes a la duree du service (cut = 60 min).
+    expect(
+      result.slots.every((slot) => slotDurationMinutes(slot) === seedServices.cut.duration),
+    ).toBe(true)
+    // Les dates affichees correspondent exactement aux jours des creneaux.
+    const slotDateKeys = new Set(result.slots.map((slot) => slot.dateKey))
+    const dateKeys = new Set(result.dates.map((date) => date.key))
+    expect(dateKeys).toEqual(slotDateKeys)
+  })
+
+  it('ne renvoie aucun creneau pour un service que le membre ne propose pas', async () => {
+    // Mila ne fait pas "beard" (service de Leo) -> filtrage member-service cote serveur.
+    const result = await publicCaller.booking.publicSlots({
+      orgSlug: seedOrganization.slug,
+      memberId: seedMembers.mila.id,
+      serviceId: seedServices.beard.id,
+    })
+
+    expect(result.slots).toHaveLength(0)
+  })
+
   it('confirme un booking avec le client de la session tRPC', async () => {
     const caller = await createUserCaller(seedUsers.clientTwo.id)
 

--- a/lib/trpc/routers/booking.ts
+++ b/lib/trpc/routers/booking.ts
@@ -5,8 +5,15 @@ import {
   confirmPublicBookingSelectionSchema,
 } from '@/lib/bookings/public-booking'
 import { BookingStatus } from '@/generated/prisma/enums'
-import { protectedProcedure, router } from '../init'
+import { getPublicBookingSlots } from '@/lib/organizations/public-organization'
+import { protectedProcedure, publicProcedure, router } from '../init'
 import { z } from 'zod'
+
+const publicSlotsInputSchema = z.object({
+  orgSlug: z.string().min(1),
+  serviceId: z.string().min(1).optional(),
+  memberId: z.string().min(1).optional(),
+})
 
 const confirmBookingProcedure = protectedProcedure
   .input(confirmPublicBookingSelectionSchema)
@@ -36,6 +43,15 @@ export const bookingRouter = router({
 
   // Alias temporaire pour garder le flow public actuel fonctionnel pendant la migration UI.
   confirmPublic: confirmBookingProcedure,
+
+  // Créneaux dispo d'une orga, exposés publiquement (page de réservation, sans login).
+  // Lit la même source que le SSR -> sert d'initialData côté client + permet le refetch.
+  publicSlots: publicProcedure.input(publicSlotsInputSchema).query(({ input }) =>
+    getPublicBookingSlots(input.orgSlug, {
+      memberId: input.memberId,
+      serviceId: input.serviceId,
+    }),
+  ),
 
   cancel: protectedProcedure
     .input(z.object({ bookingId: z.string().min(1) }))


### PR DESCRIPTION
## Quoi

La page publique de réservation (`/[org-slug]/booking/slot`) récupère désormais les créneaux via **tRPC + cache TanStack Query** au lieu d'un simple fetch serveur. Objectif : refléter côté client les disponibilités modifiées par le pro, sans recharger.

## Comment

- **Procédure** `booking.publicSlots` (publicProcedure, sans login) — lit la même source que le SSR.
- **Source unique** `getPublicBookingSlots()` partagée SSR + tRPC (DRY).
- **SSR conservé** : la page passe le résultat en `initialData` (rendu instantané, SEO).
- **Maj sans reload** : `staleTime: 0` + `refetchOnWindowFocus` + poll 10 s → le client voit les dispos du pro en revenant sur l'onglet (≤10 s).
- **Invalidation après résa** : `utils.booking.publicSlots.invalidate()` dans `confirm-booking-form` → le créneau réservé disparaît pour ce client.
- `PublicSlotPicker` reste présentationnel pur ; nouveau wrapper `public-slot-picker-live` porte la query.

## Tests

- Unit : `public-booking-slot.test.ts` (mapping pur).
- Integration : `booking.publicSlots` — filtrage membre+service, et 0 créneau si le membre ne propose pas le service.
- Au vert : typecheck + 41 unit + 36 integration.

## Note

Maj « au focus / ≤10 s », pas du push instantané. Vrai temps réel = SSE/WebSocket (hors scope).