### PR TITLE
feat: member invitations flow

### DIFF
--- a/app/(protected)/client/become-member/page.tsx
+++ b/app/(protected)/client/become-member/page.tsx
@@ -1,19 +1,47 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
 import { requireSession } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { BecomeMemberForm } from '@/components/dashboard/become-member-form'
+import { getInvitationByToken } from '@/lib/invitations/get-invitation'
+import { getInvitationState } from '@/lib/invitations/state'
+import { InvitationAcceptance } from '@/components/dashboard/invitation-acceptance'
 
-export default async function BecomeMemberPage() {
-  const session = await requireSession('/client/become-member')
+interface Props {
+  searchParams: Promise<{ token?: string }>
+}
 
-  const existingMember = await db.member.findUnique({
-    where: { userId: session.user.id },
-    select: { id: true },
-  })
+export const metadata: Metadata = { title: 'Rejoindre une organisation - CutBook' }
 
-  if (existingMember) {
-    redirect('/member')
+export default async function BecomeMemberPage({ searchParams }: Props) {
+  const { token } = await searchParams
+
+  // callbackUrl conserve le token pour revenir ici après login.
+  const callbackUrl = token
+    ? `/client/become-member?token=${encodeURIComponent(token)}`
+    : '/client/become-member'
+  const session = await requireSession(callbackUrl)
+
+  if (!token) {
+    return <InvitationAcceptance state="INVALID" />
   }
 
-  return <BecomeMemberForm userName={session.user.name ?? 'Professionnel'} />
+  const invitation = await getInvitationByToken(token)
+  if (!invitation) {
+    return <InvitationAcceptance state="INVALID" />
+  }
+
+  // Un user ne peut être membre que d'une seule orga.
+  const alreadyMember = Boolean(
+    await db.member.findUnique({ where: { userId: session.user.id }, select: { id: true } }),
+  )
+
+  const state = getInvitationState(invitation, session.user.email)
+
+  return (
+    <InvitationAcceptance
+      state={state}
+      token={token}
+      orgName={invitation.organization.name}
+      alreadyMember={alreadyMember}
+    />
+  )
 }

--- a/app/(protected)/client/create-organization/page.tsx
+++ b/app/(protected)/client/create-organization/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { requireSession } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { OrganizationCreator } from '@/components/dashboard/organization-creator'
+
+export const metadata: Metadata = { title: 'Créer mon organisation - CutBook' }
+
+export default async function CreateOrganizationPage() {
+  const session = await requireSession('/client/create-organization')
+
+  // Un user ne peut gérer qu'une seule orga : s'il est déjà membre, on l'envoie sur son espace.
+  const existingMember = await db.member.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true },
+  })
+
+  if (existingMember) {
+    redirect('/member')
+  }
+
+  return <OrganizationCreator userName={session.user.name ?? 'Professionnel'} />
+}

--- a/app/(protected)/owner/members/page.tsx
+++ b/app/(protected)/owner/members/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { requireOwner } from '@/lib/auth'
+import { OwnerMembersView } from '@/components/dashboard/owner-members-view'
+
+export const metadata: Metadata = { title: 'Équipe - CutBook' }
+
+export default async function OwnerMembersPage() {
+  await requireOwner()
+  return <OwnerMembersView />
+}

--- a/components/dashboard/client-sidebar.tsx
+++ b/components/dashboard/client-sidebar.tsx
@@ -117,13 +117,13 @@ export function ClientSidebar({
           </Link>
         ) : (
           <Link
-            id="client-sidebar-become-member"
-            href="/client/become-member"
+            id="client-sidebar-create-organization"
+            href="/client/create-organization"
             className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-semibold text-white transition-all hover:opacity-90"
             style={{ background: '#489B6E' }}
           >
             <UserRoundPlus size={16} />
-            Devenir membre
+            Devenir pro
           </Link>
         )}
       </div>

--- a/components/dashboard/invitation-acceptance.tsx
+++ b/components/dashboard/invitation-acceptance.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { AlertCircle, Building2, CheckCircle2, Loader2 } from 'lucide-react'
+import { trpc } from '@/lib/trpc/client'
+import type { InvitationState } from '@/lib/invitations/state'
+
+const C = {
+  text: '#253122',
+  muted: 'rgba(37,49,34,0.45)',
+  border: 'rgba(37,49,34,0.10)',
+  card: '#ffffff',
+  bg: '#f9f7f3',
+  green: '#489B6E',
+  greenDark: '#2d6b4a',
+  red: '#dc2626',
+  redBg: 'rgba(220,38,38,0.08)',
+}
+
+interface InvitationAcceptanceProps {
+  state: InvitationState | 'INVALID'
+  token?: string
+  orgName?: string
+  alreadyMember?: boolean
+}
+
+// Messages pour les états non-acceptables.
+const ERROR_MESSAGES: Record<Exclude<InvitationState, 'VALID'> | 'INVALID', string> = {
+  INVALID: 'Lien d’invitation invalide ou incomplet.',
+  EXPIRED: 'Cette invitation a expiré.',
+  REVOKED: 'Cette invitation a été révoquée.',
+  ACCEPTED: 'Cette invitation a déjà été acceptée.',
+  WRONG_RECIPIENT: 'Cette invitation ne correspond pas à votre compte.',
+}
+
+export function InvitationAcceptance({
+  state,
+  token,
+  orgName,
+  alreadyMember,
+}: InvitationAcceptanceProps) {
+  const router = useRouter()
+
+  const accept = trpc.invitation.accept.useMutation({
+    onSuccess: () => {
+      router.push('/member')
+      router.refresh()
+    },
+  })
+
+  const canAccept = state === 'VALID' && !alreadyMember && Boolean(token)
+
+  return (
+    <div
+      className="flex min-h-svh flex-col items-center justify-center px-4 py-16"
+      style={{ background: C.bg }}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl border p-8 text-center"
+        style={{ borderColor: C.border, background: C.card }}
+      >
+        <div
+          className="mx-auto mb-5 flex size-16 items-center justify-center rounded-2xl"
+          style={{ background: C.green }}
+        >
+          <Building2 size={28} className="text-white" />
+        </div>
+
+        {canAccept ? (
+          <>
+            <h1 className="text-2xl font-extrabold" style={{ color: C.text }}>
+              Rejoindre {orgName}
+            </h1>
+            <p className="mx-auto mt-2 max-w-sm text-sm" style={{ color: C.muted }}>
+              Vous êtes invité à rejoindre <strong>{orgName}</strong> en tant que professionnel. En
+              acceptant, vous accédez à votre espace membre (planning, prestations).
+            </p>
+
+            {accept.isError && (
+              <div
+                className="mt-5 flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-medium"
+                style={{ background: C.redBg, color: C.red }}
+              >
+                <AlertCircle size={15} />
+                {accept.error.message}
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => token && accept.mutate({ token })}
+              disabled={accept.isPending || accept.isSuccess}
+              className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ background: C.green }}
+            >
+              {accept.isPending && <Loader2 size={15} className="animate-spin" />}
+              {accept.isSuccess ? (
+                <>
+                  <CheckCircle2 size={15} /> Bienvenue dans l’équipe !
+                </>
+              ) : accept.isPending ? (
+                'Acceptation…'
+              ) : (
+                'Accepter l’invitation'
+              )}
+            </button>
+          </>
+        ) : (
+          <>
+            <h1 className="text-2xl font-extrabold" style={{ color: C.text }}>
+              Invitation indisponible
+            </h1>
+            <p className="mx-auto mt-2 max-w-sm text-sm" style={{ color: C.muted }}>
+              {alreadyMember && state === 'VALID'
+                ? 'Vous êtes déjà membre d’une organisation.'
+                : ERROR_MESSAGES[state === 'VALID' ? 'INVALID' : state]}
+            </p>
+            <Link
+              href="/client"
+              className="mt-6 inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90"
+              style={{ background: C.green }}
+            >
+              Retour à mon espace
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/invitation-acceptance.tsx
+++ b/components/dashboard/invitation-acceptance.tsx
@@ -30,6 +30,7 @@ const ERROR_MESSAGES: Record<Exclude<InvitationState, 'VALID'> | 'INVALID', stri
   INVALID: 'Lien d’invitation invalide ou incomplet.',
   EXPIRED: 'Cette invitation a expiré.',
   REVOKED: 'Cette invitation a été révoquée.',
+  DECLINED: 'Vous avez refusé cette invitation.',
   ACCEPTED: 'Cette invitation a déjà été acceptée.',
   WRONG_RECIPIENT: 'Cette invitation ne correspond pas à votre compte.',
 }
@@ -49,6 +50,14 @@ export function InvitationAcceptance({
     },
   })
 
+  const decline = trpc.invitation.decline.useMutation({
+    onSuccess: () => {
+      router.push('/client')
+      router.refresh()
+    },
+  })
+
+  const busy = accept.isPending || accept.isSuccess || decline.isPending || decline.isSuccess
   const canAccept = state === 'VALID' && !alreadyMember && Boolean(token)
 
   return (
@@ -77,20 +86,20 @@ export function InvitationAcceptance({
               acceptant, vous accédez à votre espace membre (planning, prestations).
             </p>
 
-            {accept.isError && (
+            {(accept.isError || decline.isError) && (
               <div
                 className="mt-5 flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-medium"
                 style={{ background: C.redBg, color: C.red }}
               >
                 <AlertCircle size={15} />
-                {accept.error.message}
+                {(accept.error ?? decline.error)?.message}
               </div>
             )}
 
             <button
               type="button"
               onClick={() => token && accept.mutate({ token })}
-              disabled={accept.isPending || accept.isSuccess}
+              disabled={busy}
               className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
               style={{ background: C.green }}
             >
@@ -104,6 +113,16 @@ export function InvitationAcceptance({
               ) : (
                 'Accepter l’invitation'
               )}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => token && decline.mutate({ token })}
+              disabled={busy}
+              className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-70 disabled:opacity-50"
+              style={{ color: C.muted }}
+            >
+              {decline.isPending ? 'Refus…' : 'Refuser l’invitation'}
             </button>
           </>
         ) : (

--- a/components/dashboard/organization-creator.tsx
+++ b/components/dashboard/organization-creator.tsx
@@ -35,7 +35,7 @@ function toSlug(value: string) {
   return value
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 30)
@@ -126,11 +126,11 @@ function Field({
 
 // ── Main Component ─────────────────────────────────────────────────────────────
 
-interface BecomeMemberFormProps {
+interface OrganizationCreatorProps {
   userName: string
 }
 
-export function BecomeMemberForm({ userName }: BecomeMemberFormProps) {
+export function OrganizationCreator({ userName }: OrganizationCreatorProps) {
   const router = useRouter()
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')

--- a/components/dashboard/organization-creator.tsx
+++ b/components/dashboard/organization-creator.tsx
@@ -134,7 +134,6 @@ export function OrganizationCreator({ userName }: OrganizationCreatorProps) {
   const router = useRouter()
   const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
-  const [slugEdited, setSlugEdited] = useState(false)
   const [address, setAddress] = useState('')
   const [phone, setPhone] = useState('')
   const [description, setDescription] = useState('')
@@ -147,16 +146,9 @@ export function OrganizationCreator({ userName }: OrganizationCreatorProps) {
     },
   })
 
-  // Auto-génération du slug depuis le nom
+  // Slug auto-généré depuis le nom (non éditable : une seule source de vérité = le nom).
   function handleNameChange(value: string) {
     setName(value)
-    if (!slugEdited) {
-      setSlug(toSlug(value))
-    }
-  }
-
-  function handleSlugChange(value: string) {
-    setSlugEdited(true)
     setSlug(toSlug(value))
   }
 
@@ -241,21 +233,21 @@ export function OrganizationCreator({ userName }: OrganizationCreatorProps) {
           />
         </FieldGroup>
 
-        {/* Slug */}
+        {/* Slug — généré automatiquement depuis le nom, non éditable */}
         <FieldGroup
           id="org-slug"
           label="Identifiant URL"
-          hint={`Votre page sera accessible sur /${slug || 'mon-salon'}`}
+          hint={`Généré automatiquement : cutbook.fr/${slug || 'mon-salon'}`}
           error={fieldErrors.slug ?? (isSlugConflict ? create.error?.message : undefined)}
         >
           <Field
             id="org-slug"
             value={slug}
-            onChange={handleSlugChange}
+            onChange={() => undefined}
             prefix="cutbook.fr/"
             placeholder="mon-salon"
             maxLength={30}
-            disabled={create.isPending || create.isSuccess}
+            disabled
           />
         </FieldGroup>
 

--- a/components/dashboard/owner-members-view.tsx
+++ b/components/dashboard/owner-members-view.tsx
@@ -92,9 +92,13 @@ export function OwnerMembersView() {
   const membersQuery = trpc.organization.teamMembers.useQuery()
   const invitationsQuery = trpc.invitation.listPending.useQuery()
 
+  // Confirmation inline du retrait d'un membre (pas de suppression directe au clic).
+  const [confirmingId, setConfirmingId] = useState<string | null>(null)
+
   const removeMember = trpc.organization.removeMember.useMutation({
     onSuccess() {
       toast.success('Professionnel retiré')
+      setConfirmingId(null)
       utils.organization.teamMembers.invalidate()
     },
     onError: (e) => toast.error(e.message),
@@ -144,18 +148,42 @@ export function OwnerMembersView() {
                 </p>
                 <p className="text-muted-foreground truncate text-sm">{member.email}</p>
               </div>
-              {!member.isOwner && (
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="text-destructive hover:text-destructive"
-                  aria-label="Retirer le professionnel"
-                  disabled={removeMember.isPending}
-                  onClick={() => removeMember.mutate({ memberId: member.id })}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              )}
+              {!member.isOwner &&
+                (confirmingId === member.id ? (
+                  <div className="flex shrink-0 items-center gap-1">
+                    <span className="text-muted-foreground hidden text-xs sm:inline">
+                      Retirer ?
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      disabled={removeMember.isPending}
+                      onClick={() => removeMember.mutate({ memberId: member.id })}
+                    >
+                      {removeMember.isPending && <Loader2 className="size-3.5 animate-spin" />}
+                      Confirmer
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={removeMember.isPending}
+                      onClick={() => setConfirmingId(null)}
+                    >
+                      Annuler
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="text-destructive hover:text-destructive"
+                    aria-label="Retirer le professionnel"
+                    onClick={() => setConfirmingId(member.id)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                ))}
             </article>
           ))
         )}

--- a/components/dashboard/owner-members-view.tsx
+++ b/components/dashboard/owner-members-view.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { useState } from 'react'
+import { Check, Copy, Loader2, Mail, Trash2, UserPlus, Users } from 'lucide-react'
+import { toast } from 'sonner'
+import { trpc } from '@/lib/trpc/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+
+// ── Formulaire de recrutement ────────────────────────────────────────────────
+function RecruitForm() {
+  const utils = trpc.useUtils()
+  const [email, setEmail] = useState('')
+
+  const create = trpc.invitation.create.useMutation({
+    onSuccess() {
+      toast.success('Invitation envoyée')
+      utils.invitation.listPending.invalidate()
+      setEmail('')
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = email.trim()
+    if (!trimmed) return toast.error('Email requis.')
+    create.mutate({ email: trimmed })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-card flex flex-col gap-3 rounded-xl border p-5 shadow-sm"
+    >
+      <div>
+        <h2 className="text-foreground font-semibold">Recruter un professionnel</h2>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Saisissez l’email d’un client de la plateforme. Il recevra un lien pour rejoindre votre
+          équipe.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="recruit-email">Email du client</Label>
+        <div className="flex gap-2">
+          <Input
+            id="recruit-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="client@example.com"
+          />
+          <Button type="submit" disabled={create.isPending}>
+            {create.isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Mail className="size-4" />
+            )}
+            Inviter
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}
+
+// ── Bouton "copier le lien d'invitation" ─────────────────────────────────────
+function CopyLinkButton({ token }: { token: string }) {
+  const [copied, setCopied] = useState(false)
+
+  function copy() {
+    const url = `${window.location.origin}/client/become-member?token=${encodeURIComponent(token)}`
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <Button size="sm" variant="ghost" onClick={copy}>
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      {copied ? 'Copié' : 'Copier le lien'}
+    </Button>
+  )
+}
+
+// ── Vue principale ───────────────────────────────────────────────────────────
+export function OwnerMembersView() {
+  const utils = trpc.useUtils()
+  const membersQuery = trpc.organization.teamMembers.useQuery()
+  const invitationsQuery = trpc.invitation.listPending.useQuery()
+
+  const removeMember = trpc.organization.removeMember.useMutation({
+    onSuccess() {
+      toast.success('Professionnel retiré')
+      utils.organization.teamMembers.invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  const revoke = trpc.invitation.revoke.useMutation({
+    onSuccess() {
+      toast.success('Invitation révoquée')
+      utils.invitation.listPending.invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  const members = membersQuery.data ?? []
+  const invitations = invitationsQuery.data ?? []
+
+  return (
+    <main className="flex w-full max-w-3xl flex-col gap-6 p-6 lg:p-8">
+      <div>
+        <h1 className="text-foreground text-2xl font-bold">Équipe</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Gérez les professionnels de votre salon et recrutez de nouveaux membres.
+        </p>
+      </div>
+
+      <RecruitForm />
+
+      {/* Membres actuels */}
+      <section className="flex flex-col gap-3">
+        <h2 className="text-foreground flex items-center gap-2 font-semibold">
+          <Users className="size-4" /> Professionnels ({members.length})
+        </h2>
+        {membersQuery.isLoading ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Loader2 className="size-4 animate-spin" /> Chargement…
+          </div>
+        ) : (
+          members.map((member) => (
+            <article
+              key={member.id}
+              className="bg-card flex items-center justify-between gap-3 rounded-xl border p-4 shadow-sm"
+            >
+              <div className="min-w-0">
+                <p className="text-foreground flex items-center gap-2 font-semibold">
+                  {member.name}
+                  {member.isOwner && <Badge variant="secondary">Gérant</Badge>}
+                </p>
+                <p className="text-muted-foreground truncate text-sm">{member.email}</p>
+              </div>
+              {!member.isOwner && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  aria-label="Retirer le professionnel"
+                  disabled={removeMember.isPending}
+                  onClick={() => removeMember.mutate({ memberId: member.id })}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              )}
+            </article>
+          ))
+        )}
+      </section>
+
+      {/* Invitations en attente */}
+      <section className="flex flex-col gap-3">
+        <h2 className="text-foreground flex items-center gap-2 font-semibold">
+          <UserPlus className="size-4" /> Invitations en attente ({invitations.length})
+        </h2>
+        {invitations.length === 0 ? (
+          <div className="bg-muted/40 rounded-xl border border-dashed p-6 text-center">
+            <p className="text-muted-foreground text-sm">Aucune invitation en attente.</p>
+          </div>
+        ) : (
+          invitations.map((invitation) => (
+            <article
+              key={invitation.id}
+              className="bg-card flex items-center justify-between gap-3 rounded-xl border p-4 shadow-sm"
+            >
+              <div className="min-w-0">
+                <p className="text-foreground flex items-center gap-2 truncate font-medium">
+                  {invitation.email}
+                  {invitation.isExpired && <Badge variant="destructive">Expirée</Badge>}
+                </p>
+                <p className="text-muted-foreground text-xs">
+                  Expire le{' '}
+                  {new Intl.DateTimeFormat('fr-FR', { dateStyle: 'long' }).format(
+                    new Date(invitation.expiresAt),
+                  )}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <CopyLinkButton token={invitation.token} />
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  disabled={revoke.isPending}
+                  onClick={() => revoke.mutate({ invitationId: invitation.id })}
+                >
+                  Révoquer
+                </Button>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+    </main>
+  )
+}

--- a/components/dashboard/owner-sidebar.tsx
+++ b/components/dashboard/owner-sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { LayoutDashboard, Scissors, Tag, ArrowLeftRight, UserRound } from 'lucide-react'
+import { LayoutDashboard, Scissors, Tag, Users, ArrowLeftRight, UserRound } from 'lucide-react'
 import Link from 'next/link'
 import { NavMain } from '@/components/nav-main'
 import { NavUser } from '@/components/nav-user'
@@ -20,6 +20,7 @@ import {
 const navMain = [
   { title: 'Tableau de bord', url: '/owner', icon: <LayoutDashboard /> },
   { title: 'Services', url: '/owner/services', icon: <Tag /> },
+  { title: 'Équipe', url: '/owner/members', icon: <Users /> },
 ]
 
 interface OwnerSidebarProps extends React.ComponentProps<typeof Sidebar> {

--- a/components/layout/public-navbar.tsx
+++ b/components/layout/public-navbar.tsx
@@ -32,7 +32,11 @@ export async function PublicNavbar() {
           Trouver un pro
         </Link>
         <Link
-          href={session ? '/client/become-member' : '/login?callbackUrl=/client/become-member'}
+          href={
+            session
+              ? '/client/create-organization'
+              : '/login?callbackUrl=/client/create-organization'
+          }
           className="rounded-lg border px-3 py-1.5 text-sm font-semibold transition-opacity hover:opacity-80"
           style={{ borderColor: 'rgba(72,155,110,0.4)', color: '#489B6E' }}
         >

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -89,3 +89,4 @@ export async function sendEmail({ to, subject, react, text, tags }: SendEmailOpt
 }
 
 export { VerifyEmailTemplate } from './templates/verify-email-template'
+export { MemberInvitationTemplate } from './templates/member-invitation-template'

--- a/lib/email/templates/member-invitation-template.tsx
+++ b/lib/email/templates/member-invitation-template.tsx
@@ -1,0 +1,67 @@
+import { Button, Link, Text } from '@react-email/components'
+import { EmailShell, emailStyles } from './email-shell'
+
+interface MemberInvitationTemplateProps {
+  orgName: string
+  inviterName?: string | null
+  acceptUrl: string
+}
+
+const buttonStyle = {
+  display: 'inline-block',
+  borderRadius: '8px',
+  backgroundColor: emailStyles.colors.green500,
+  color: '#ffffff',
+  fontSize: '14px',
+  fontWeight: '700',
+  lineHeight: '1',
+  padding: '14px 22px',
+  textDecoration: 'none',
+}
+
+const linkStyle = {
+  color: emailStyles.colors.green600,
+  fontWeight: '600',
+  textDecoration: 'underline',
+  textUnderlineOffset: '3px',
+}
+
+export function MemberInvitationTemplate({
+  orgName,
+  inviterName,
+  acceptUrl,
+}: MemberInvitationTemplateProps) {
+  const intro = inviterName
+    ? `${inviterName} vous invite a rejoindre ${orgName} sur CutBook.`
+    : `Vous etes invite a rejoindre ${orgName} sur CutBook.`
+
+  return (
+    <EmailShell
+      preview={`Rejoignez ${orgName} sur CutBook`}
+      eyebrow="Invitation equipe"
+      title={`Rejoignez ${orgName}`}
+    >
+      <Text style={emailStyles.text}>Bonjour,</Text>
+      <Text style={emailStyles.text}>
+        {intro} En acceptant, vous devenez membre de l&apos;equipe et pourrez gerer votre planning
+        et vos prestations.
+      </Text>
+
+      <Button href={acceptUrl} style={buttonStyle}>
+        Accepter l&apos;invitation
+      </Button>
+
+      <Text style={emailStyles.mutedText}>
+        Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :{' '}
+        <Link href={acceptUrl} style={linkStyle}>
+          {acceptUrl}
+        </Link>
+      </Text>
+
+      <Text style={emailStyles.mutedText}>
+        Ce lien expire dans 7 jours. Si vous n&apos;attendiez pas cette invitation, ignorez cet
+        email.
+      </Text>
+    </EmailShell>
+  )
+}

--- a/lib/invitations/email.ts
+++ b/lib/invitations/email.ts
@@ -1,0 +1,33 @@
+import { getServerAppUrl } from '@/lib/env'
+import { MemberInvitationTemplate, sendEmail } from '@/lib/email'
+
+interface SendMemberInvitationEmailInput {
+  to: string
+  orgName: string
+  inviterName?: string | null
+  token: string
+}
+
+/**
+ * Envoie l'email d'invitation. **Best-effort** : un échec d'envoi (Mailpit/Resend KO)
+ * ne doit pas faire échouer la création de l'invitation (ni casser les tests d'intégration).
+ */
+export async function sendMemberInvitationEmail({
+  to,
+  orgName,
+  inviterName,
+  token,
+}: SendMemberInvitationEmailInput) {
+  const acceptUrl = `${getServerAppUrl()}/client/become-member?token=${encodeURIComponent(token)}`
+
+  try {
+    await sendEmail({
+      to,
+      subject: `Invitation a rejoindre ${orgName} sur CutBook`,
+      react: MemberInvitationTemplate({ orgName, inviterName, acceptUrl }),
+      tags: [{ name: 'type', value: 'member-invitation' }],
+    })
+  } catch (error) {
+    console.error('[invitation] envoi email echoue:', error)
+  }
+}

--- a/lib/invitations/get-invitation.ts
+++ b/lib/invitations/get-invitation.ts
@@ -1,0 +1,18 @@
+import { db } from '@/lib/db'
+
+/**
+ * Lecture d'une invitation par son token, pour la page d'acceptation (Server Component).
+ * Retourne l'invitation + l'orga, ou null si le token est inconnu.
+ */
+export async function getInvitationByToken(token: string) {
+  return await db.memberInvitation.findUnique({
+    where: { token },
+    select: {
+      id: true,
+      email: true,
+      status: true,
+      expiresAt: true,
+      organization: { select: { id: true, name: true, slug: true } },
+    },
+  })
+}

--- a/lib/invitations/schema.test.ts
+++ b/lib/invitations/schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { recruitEmailSchema } from './schema'
+
+describe('recruitEmailSchema', () => {
+  it('accepte un email valide', () => {
+    expect(recruitEmailSchema.safeParse({ email: 'client@cutbook.test' }).success).toBe(true)
+  })
+
+  it('refuse un email mal formé', () => {
+    expect(recruitEmailSchema.safeParse({ email: 'pas-un-email' }).success).toBe(false)
+  })
+
+  it('refuse un email vide', () => {
+    expect(recruitEmailSchema.safeParse({ email: '' }).success).toBe(false)
+  })
+})

--- a/lib/invitations/schema.ts
+++ b/lib/invitations/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+// Recrutement : seul l'email est saisi par le owner (l'orga vient du contexte serveur).
+export const recruitEmailSchema = z.object({
+  email: z.string().min(1, 'Email requis').email('Email invalide'),
+})
+
+export const invitationTokenSchema = z.object({
+  token: z.string().min(1),
+})
+
+export const invitationIdSchema = z.object({
+  invitationId: z.string().min(1),
+})

--- a/lib/invitations/state.test.ts
+++ b/lib/invitations/state.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { InvitationStatus } from '@/generated/prisma/enums'
+import { getInvitationExpiry, getInvitationState, INVITATION_TTL_DAYS } from './state'
+
+const now = new Date('2026-05-28T00:00:00.000Z')
+const base = {
+  status: InvitationStatus.PENDING,
+  expiresAt: new Date('2026-06-01T00:00:00.000Z'),
+  email: 'client@cutbook.test',
+}
+
+describe('getInvitationState', () => {
+  it('VALID si PENDING, non expirée, bon destinataire', () => {
+    expect(getInvitationState(base, 'client@cutbook.test', now)).toBe('VALID')
+  })
+
+  it('insensible à la casse de l’email', () => {
+    expect(getInvitationState(base, 'CLIENT@CutBook.test', now)).toBe('VALID')
+  })
+
+  it('ACCEPTED prioritaire si déjà acceptée', () => {
+    expect(
+      getInvitationState(
+        { ...base, status: InvitationStatus.ACCEPTED },
+        'client@cutbook.test',
+        now,
+      ),
+    ).toBe('ACCEPTED')
+  })
+
+  it('REVOKED si révoquée', () => {
+    expect(
+      getInvitationState({ ...base, status: InvitationStatus.REVOKED }, 'client@cutbook.test', now),
+    ).toBe('REVOKED')
+  })
+
+  it('EXPIRED si expiresAt < now', () => {
+    expect(
+      getInvitationState(
+        { ...base, expiresAt: new Date('2026-05-01T00:00:00.000Z') },
+        'client@cutbook.test',
+        now,
+      ),
+    ).toBe('EXPIRED')
+  })
+
+  it('WRONG_RECIPIENT si l’email ne correspond pas', () => {
+    expect(getInvitationState(base, 'autre@cutbook.test', now)).toBe('WRONG_RECIPIENT')
+  })
+})
+
+describe('getInvitationExpiry', () => {
+  it(`ajoute ${INVITATION_TTL_DAYS} jours`, () => {
+    const from = new Date('2026-05-28T10:00:00.000Z')
+    const expiry = getInvitationExpiry(from)
+    const diffDays = Math.round((expiry.getTime() - from.getTime()) / (24 * 60 * 60 * 1000))
+    expect(diffDays).toBe(INVITATION_TTL_DAYS)
+  })
+})

--- a/lib/invitations/state.test.ts
+++ b/lib/invitations/state.test.ts
@@ -34,6 +34,16 @@ describe('getInvitationState', () => {
     ).toBe('REVOKED')
   })
 
+  it('DECLINED si refusée par le destinataire', () => {
+    expect(
+      getInvitationState(
+        { ...base, status: InvitationStatus.DECLINED },
+        'client@cutbook.test',
+        now,
+      ),
+    ).toBe('DECLINED')
+  })
+
   it('EXPIRED si expiresAt < now', () => {
     expect(
       getInvitationState(

--- a/lib/invitations/state.ts
+++ b/lib/invitations/state.ts
@@ -9,7 +9,13 @@ export function getInvitationExpiry(from: Date = new Date()): Date {
   return expiry
 }
 
-export type InvitationState = 'VALID' | 'EXPIRED' | 'REVOKED' | 'ACCEPTED' | 'WRONG_RECIPIENT'
+export type InvitationState =
+  | 'VALID'
+  | 'EXPIRED'
+  | 'REVOKED'
+  | 'DECLINED'
+  | 'ACCEPTED'
+  | 'WRONG_RECIPIENT'
 
 interface InvitationStateInput {
   status: InvitationStatus
@@ -20,7 +26,7 @@ interface InvitationStateInput {
 /**
  * Logique PURE (sans BDD) : décide l'état d'une invitation pour un user donné.
  * Réutilisée par `invitation.accept` (serveur) ET la page d'acceptation become-member.
- * Ordre de priorité : ACCEPTED > REVOKED > EXPIRED > WRONG_RECIPIENT > VALID.
+ * Ordre de priorité : ACCEPTED > REVOKED > DECLINED > EXPIRED > WRONG_RECIPIENT > VALID.
  */
 export function getInvitationState(
   invitation: InvitationStateInput,
@@ -29,6 +35,7 @@ export function getInvitationState(
 ): InvitationState {
   if (invitation.status === InvitationStatus.ACCEPTED) return 'ACCEPTED'
   if (invitation.status === InvitationStatus.REVOKED) return 'REVOKED'
+  if (invitation.status === InvitationStatus.DECLINED) return 'DECLINED'
   if (invitation.expiresAt.getTime() < now.getTime()) return 'EXPIRED'
   if (invitation.email.toLowerCase() !== userEmail.toLowerCase()) return 'WRONG_RECIPIENT'
   return 'VALID'

--- a/lib/invitations/state.ts
+++ b/lib/invitations/state.ts
@@ -1,0 +1,35 @@
+import { InvitationStatus } from '@/generated/prisma/enums'
+
+export const INVITATION_TTL_DAYS = 7
+
+// Date d'expiration = maintenant + TTL. Isolé ici pour rester la seule source de vérité du délai.
+export function getInvitationExpiry(from: Date = new Date()): Date {
+  const expiry = new Date(from)
+  expiry.setDate(expiry.getDate() + INVITATION_TTL_DAYS)
+  return expiry
+}
+
+export type InvitationState = 'VALID' | 'EXPIRED' | 'REVOKED' | 'ACCEPTED' | 'WRONG_RECIPIENT'
+
+interface InvitationStateInput {
+  status: InvitationStatus
+  expiresAt: Date
+  email: string
+}
+
+/**
+ * Logique PURE (sans BDD) : décide l'état d'une invitation pour un user donné.
+ * Réutilisée par `invitation.accept` (serveur) ET la page d'acceptation become-member.
+ * Ordre de priorité : ACCEPTED > REVOKED > EXPIRED > WRONG_RECIPIENT > VALID.
+ */
+export function getInvitationState(
+  invitation: InvitationStateInput,
+  userEmail: string,
+  now: Date = new Date(),
+): InvitationState {
+  if (invitation.status === InvitationStatus.ACCEPTED) return 'ACCEPTED'
+  if (invitation.status === InvitationStatus.REVOKED) return 'REVOKED'
+  if (invitation.expiresAt.getTime() < now.getTime()) return 'EXPIRED'
+  if (invitation.email.toLowerCase() !== userEmail.toLowerCase()) return 'WRONG_RECIPIENT'
+  return 'VALID'
+}

--- a/lib/trpc/owner.ts
+++ b/lib/trpc/owner.ts
@@ -1,0 +1,20 @@
+// Helper partagé : résout l'organisation possédée par l'utilisateur courant (owner).
+// "Être owner" = relation Organization.ownerId (pas un role plateforme).
+// Dérivé du contexte (jamais d'orgId envoyé par le client) -> pas d'usurpation possible.
+import { TRPCError } from '@trpc/server'
+
+export async function getOwnedOrg(ctx: { db: typeof import('@/lib/db').db; user: { id: string } }) {
+  const organization = await ctx.db.organization.findUnique({
+    where: { ownerId: ctx.user.id },
+    select: { id: true, name: true, slug: true, ownerId: true },
+  })
+
+  if (!organization) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Vous ne gerez aucune organisation.',
+    })
+  }
+
+  return organization
+}

--- a/lib/trpc/routers/index.ts
+++ b/lib/trpc/routers/index.ts
@@ -4,6 +4,7 @@ import { router } from '../init'
 import { adminRouter } from './admin'
 import { bookingRouter } from './booking'
 import { clientRouter } from './client'
+import { invitationRouter } from './invitation'
 import { memberRouter } from './member'
 import { organizationRouter } from './organization'
 import { serviceRouter } from './service'
@@ -15,6 +16,7 @@ export const appRouter = router({
   booking: bookingRouter,
   service: serviceRouter,
   timeSlot: timeSlotRouter,
+  invitation: invitationRouter,
   clientPortal: clientRouter,
   memberPortal: memberRouter,
   // review: reviewRouter,      // TODO

--- a/lib/trpc/routers/invitation.integration.test.ts
+++ b/lib/trpc/routers/invitation.integration.test.ts
@@ -107,6 +107,28 @@ describe('invitationRouter + gestion equipe', () => {
     expect(updated?.status).toBe(InvitationStatus.REVOKED)
   })
 
+  it('le destinataire refuse une invitation', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const invite = await owner.invitation.create({ email: seedUsers.clientTwo.email })
+
+    const client = await createUserCaller(seedUsers.clientTwo.id)
+    const result = await client.invitation.decline({ token: invite.token })
+    expect(result.id).toBe(invite.id)
+
+    const updated = await db.memberInvitation.findUnique({ where: { id: invite.id } })
+    expect(updated?.status).toBe(InvitationStatus.DECLINED)
+  })
+
+  it('refuse d’accepter une invitation deja refusee', async () => {
+    const invitation = await db.memberInvitation.findFirstOrThrow({
+      where: { email: seedUsers.clientTwo.email.toLowerCase(), status: InvitationStatus.DECLINED },
+    })
+    const client = await createUserCaller(seedUsers.clientTwo.id)
+    await expect(client.invitation.accept({ token: invitation.token })).rejects.toMatchObject({
+      code: 'BAD_REQUEST' satisfies TRPCError['code'],
+    })
+  })
+
   it('liste l’equipe incluant le membre fraichement accepte', async () => {
     const owner = await createUserCaller(seedUsers.owner.id)
     const team = await owner.organization.teamMembers()

--- a/lib/trpc/routers/invitation.integration.test.ts
+++ b/lib/trpc/routers/invitation.integration.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+import 'dotenv/config'
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { TRPCError } from '@trpc/server'
+import { runSeed, seedMembers, seedOrganization, seedUsers } from '@/prisma/seed'
+import { db } from '@/lib/db'
+import { InvitationStatus } from '@/generated/prisma/enums'
+import { appRouter } from '.'
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL is required to run integration tests')
+}
+
+async function createUserCaller(userId: string) {
+  const user = await db.user.findUniqueOrThrow({ where: { id: userId } })
+  const session = {
+    id: `test-session-${user.id}`,
+    token: `test-token-${user.id}`,
+    userId: user.id,
+    expiresAt: new Date(Date.now() + 60_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: null,
+    userAgent: null,
+  }
+
+  return appRouter.createCaller({ db, session: { session, user }, user })
+}
+
+describe('invitationRouter + gestion equipe', () => {
+  beforeAll(async () => {
+    await runSeed()
+  })
+
+  it('le owner invite un client de la plateforme', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const result = await owner.invitation.create({ email: seedUsers.clientOne.email })
+
+    expect(result.email).toBe(seedUsers.clientOne.email.toLowerCase())
+    expect(result.token).toEqual(expect.any(String))
+
+    const row = await db.memberInvitation.findUnique({ where: { id: result.id } })
+    expect(row?.status).toBe(InvitationStatus.PENDING)
+    expect(row?.orgId).toBe(seedOrganization.id)
+  })
+
+  it('refuse un email inconnu de la plateforme', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    await expect(owner.invitation.create({ email: 'inconnu@nowhere.test' })).rejects.toMatchObject({
+      code: 'NOT_FOUND' satisfies TRPCError['code'],
+    })
+  })
+
+  it('refuse un client deja membre d’une orga', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    await expect(
+      owner.invitation.create({ email: seedUsers.memberOne.email }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' satisfies TRPCError['code'] })
+  })
+
+  it('refuse une invitation en double', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    await expect(
+      owner.invitation.create({ email: seedUsers.clientOne.email }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' satisfies TRPCError['code'] })
+  })
+
+  it('le destinataire accepte et devient membre', async () => {
+    const invitation = await db.memberInvitation.findFirstOrThrow({
+      where: { email: seedUsers.clientOne.email.toLowerCase(), status: InvitationStatus.PENDING },
+    })
+
+    const client = await createUserCaller(seedUsers.clientOne.id)
+    const result = await client.invitation.accept({ token: invitation.token })
+
+    expect(result.orgId).toBe(seedOrganization.id)
+
+    const member = await db.member.findUnique({ where: { userId: seedUsers.clientOne.id } })
+    expect(member?.orgId).toBe(seedOrganization.id)
+
+    const updated = await db.memberInvitation.findUnique({ where: { id: invitation.id } })
+    expect(updated?.status).toBe(InvitationStatus.ACCEPTED)
+  })
+
+  it('refuse l’acceptation par le mauvais destinataire', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const inviteTwo = await owner.invitation.create({ email: seedUsers.clientTwo.email })
+
+    const wrongUser = await createUserCaller(seedUsers.clientOne.id)
+    await expect(wrongUser.invitation.accept({ token: inviteTwo.token })).rejects.toMatchObject({
+      code: 'FORBIDDEN' satisfies TRPCError['code'],
+    })
+  })
+
+  it('le owner revoque une invitation en attente', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const invitation = await db.memberInvitation.findFirstOrThrow({
+      where: { email: seedUsers.clientTwo.email.toLowerCase(), status: InvitationStatus.PENDING },
+    })
+
+    const result = await owner.invitation.revoke({ invitationId: invitation.id })
+    expect(result.id).toBe(invitation.id)
+
+    const updated = await db.memberInvitation.findUnique({ where: { id: invitation.id } })
+    expect(updated?.status).toBe(InvitationStatus.REVOKED)
+  })
+
+  it('liste l’equipe incluant le membre fraichement accepte', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const team = await owner.organization.teamMembers()
+
+    expect(team.some((member) => member.email === seedUsers.clientOne.email)).toBe(true)
+  })
+
+  it('le owner ne peut pas se retirer lui-meme', async () => {
+    // Le seed ne crée pas la ligne Member du owner (uniquement ownerId) : on la crée.
+    const ownerMember = await db.member.upsert({
+      where: { userId: seedUsers.owner.id },
+      create: { userId: seedUsers.owner.id, orgId: seedOrganization.id },
+      update: {},
+    })
+
+    const owner = await createUserCaller(seedUsers.owner.id)
+    await expect(
+      owner.organization.removeMember({ memberId: ownerMember.id }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' satisfies TRPCError['code'] })
+  })
+
+  it('refuse de retirer un membre ayant des reservations', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    await expect(
+      owner.organization.removeMember({ memberId: seedMembers.leo.id }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' satisfies TRPCError['code'] })
+  })
+
+  it('retire un membre sans reservation', async () => {
+    const owner = await createUserCaller(seedUsers.owner.id)
+    const newMember = await db.member.findUniqueOrThrow({
+      where: { userId: seedUsers.clientOne.id },
+    })
+
+    const result = await owner.organization.removeMember({ memberId: newMember.id })
+    expect(result.memberId).toBe(newMember.id)
+
+    const gone = await db.member.findUnique({ where: { id: newMember.id } })
+    expect(gone).toBeNull()
+  })
+})

--- a/lib/trpc/routers/invitation.ts
+++ b/lib/trpc/routers/invitation.ts
@@ -149,10 +149,11 @@ export const invitationRouter = router({
     }
 
     if (state !== 'VALID') {
-      // state est ici narrowé à ACCEPTED | REVOKED | EXPIRED (WRONG_RECIPIENT déjà géré).
+      // state narrowé à ACCEPTED | REVOKED | DECLINED | EXPIRED (WRONG_RECIPIENT déjà géré).
       const messages = {
         EXPIRED: 'Cette invitation a expire.',
         REVOKED: 'Cette invitation a ete revoquee.',
+        DECLINED: 'Vous avez refuse cette invitation.',
         ACCEPTED: 'Cette invitation a deja ete acceptee.',
       } as const
       throw new TRPCError({ code: 'BAD_REQUEST', message: messages[state] })
@@ -182,5 +183,37 @@ export const invitationRouter = router({
     })
 
     return { orgId: invitation.orgId }
+  }),
+
+  // Refus par le recrute connecte (email doit matcher) : passe l'invitation en DECLINED.
+  decline: protectedProcedure.input(invitationTokenSchema).mutation(async ({ ctx, input }) => {
+    const invitation = await ctx.db.memberInvitation.findUnique({
+      where: { token: input.token },
+      select: { id: true, email: true, status: true, expiresAt: true },
+    })
+
+    if (!invitation) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Invitation introuvable.' })
+    }
+
+    const state = getInvitationState(invitation, ctx.user.email, new Date())
+
+    if (state === 'WRONG_RECIPIENT') {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Cette invitation ne vous est pas destinee.',
+      })
+    }
+
+    if (state !== 'VALID') {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cette invitation est deja traitee.' })
+    }
+
+    await ctx.db.memberInvitation.update({
+      where: { id: invitation.id },
+      data: { status: InvitationStatus.DECLINED },
+    })
+
+    return { id: invitation.id }
   }),
 })

--- a/lib/trpc/routers/invitation.ts
+++ b/lib/trpc/routers/invitation.ts
@@ -1,0 +1,186 @@
+// Router tRPC pour les invitations membres (recrutement + acceptation).
+import { TRPCError } from '@trpc/server'
+import { InvitationStatus, Role } from '@/generated/prisma/enums'
+import {
+  invitationIdSchema,
+  invitationTokenSchema,
+  recruitEmailSchema,
+} from '@/lib/invitations/schema'
+import { getInvitationExpiry, getInvitationState } from '@/lib/invitations/state'
+import { sendMemberInvitationEmail } from '@/lib/invitations/email'
+import { protectedProcedure, router } from '../init'
+import { getOwnedOrg } from '../owner'
+
+export const invitationRouter = router({
+  // Recrutement (owner) : invite un client de la plateforme a rejoindre l'orga.
+  create: protectedProcedure.input(recruitEmailSchema).mutation(async ({ ctx, input }) => {
+    const org = await getOwnedOrg(ctx)
+    const email = input.email.toLowerCase().trim()
+
+    // Le recrute doit etre un client INSCRIT (sinon on n'envoie rien).
+    const target = await ctx.db.user.findUnique({
+      where: { email },
+      select: { id: true, role: true },
+    })
+
+    if (!target) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Aucun client de la plateforme avec cet email.',
+      })
+    }
+
+    if (target.role !== Role.CLIENT) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Seul un client peut etre recrute.' })
+    }
+
+    if (target.id === ctx.user.id) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Vous ne pouvez pas vous inviter.' })
+    }
+
+    // 1 user = 1 orga : refus si deja membre quelque part.
+    const existingMember = await ctx.db.member.findUnique({
+      where: { userId: target.id },
+      select: { id: true },
+    })
+
+    if (existingMember) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Ce client est deja membre d’une organisation.',
+      })
+    }
+
+    // Une seule invitation PENDING non-expiree par (orga, email).
+    const pending = await ctx.db.memberInvitation.findFirst({
+      where: {
+        orgId: org.id,
+        email,
+        status: InvitationStatus.PENDING,
+        expiresAt: { gt: new Date() },
+      },
+      select: { id: true },
+    })
+
+    if (pending) {
+      throw new TRPCError({ code: 'CONFLICT', message: 'Une invitation est deja en attente.' })
+    }
+
+    const invitation = await ctx.db.memberInvitation.create({
+      data: {
+        email,
+        orgId: org.id,
+        invitedById: ctx.user.id,
+        expiresAt: getInvitationExpiry(),
+      },
+      select: { id: true, email: true, token: true, expiresAt: true },
+    })
+
+    await sendMemberInvitationEmail({
+      to: email,
+      orgName: org.name,
+      inviterName: ctx.user.name,
+      token: invitation.token,
+    })
+
+    return invitation
+  }),
+
+  // Liste des invitations en attente de l'orga (owner) + flag d'expiration.
+  listPending: protectedProcedure.query(async ({ ctx }) => {
+    const org = await getOwnedOrg(ctx)
+
+    const invitations = await ctx.db.memberInvitation.findMany({
+      where: { orgId: org.id, status: InvitationStatus.PENDING },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, email: true, token: true, expiresAt: true, createdAt: true },
+    })
+
+    const now = Date.now()
+    return invitations.map((invitation) => ({
+      ...invitation,
+      isExpired: invitation.expiresAt.getTime() < now,
+    }))
+  }),
+
+  // Revocation d'une invitation en attente (owner).
+  revoke: protectedProcedure.input(invitationIdSchema).mutation(async ({ ctx, input }) => {
+    const org = await getOwnedOrg(ctx)
+
+    const invitation = await ctx.db.memberInvitation.findUnique({
+      where: { id: input.invitationId },
+      select: { id: true, orgId: true, status: true },
+    })
+
+    if (!invitation || invitation.orgId !== org.id) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Invitation introuvable.' })
+    }
+
+    if (invitation.status !== InvitationStatus.PENDING) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cette invitation est deja traitee.' })
+    }
+
+    await ctx.db.memberInvitation.update({
+      where: { id: invitation.id },
+      data: { status: InvitationStatus.REVOKED },
+    })
+
+    return { id: invitation.id }
+  }),
+
+  // Acceptation par le recrute connecte (email doit matcher l'invitation).
+  accept: protectedProcedure.input(invitationTokenSchema).mutation(async ({ ctx, input }) => {
+    const invitation = await ctx.db.memberInvitation.findUnique({
+      where: { token: input.token },
+      select: { id: true, email: true, status: true, expiresAt: true, orgId: true },
+    })
+
+    if (!invitation) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Invitation introuvable.' })
+    }
+
+    const state = getInvitationState(invitation, ctx.user.email, new Date())
+
+    if (state === 'WRONG_RECIPIENT') {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Cette invitation ne vous est pas destinee.',
+      })
+    }
+
+    if (state !== 'VALID') {
+      // state est ici narrowé à ACCEPTED | REVOKED | EXPIRED (WRONG_RECIPIENT déjà géré).
+      const messages = {
+        EXPIRED: 'Cette invitation a expire.',
+        REVOKED: 'Cette invitation a ete revoquee.',
+        ACCEPTED: 'Cette invitation a deja ete acceptee.',
+      } as const
+      throw new TRPCError({ code: 'BAD_REQUEST', message: messages[state] })
+    }
+
+    // Re-check 1 user = 1 orga dans la transaction (course possible).
+    const existingMember = await ctx.db.member.findUnique({
+      where: { userId: ctx.user.id },
+      select: { id: true },
+    })
+
+    if (existingMember) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Vous etes deja membre d’une organisation.',
+      })
+    }
+
+    await ctx.db.$transaction(async (tx) => {
+      await tx.member.create({
+        data: { userId: ctx.user.id, orgId: invitation.orgId },
+      })
+      await tx.memberInvitation.update({
+        where: { id: invitation.id },
+        data: { status: InvitationStatus.ACCEPTED, acceptedAt: new Date() },
+      })
+    })
+
+    return { orgId: invitation.orgId }
+  }),
+})

--- a/lib/trpc/routers/organization.ts
+++ b/lib/trpc/routers/organization.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { TRPCError } from '@trpc/server'
 import { createOrganizationSchema, organizationSlugSchema } from '@/lib/organizations/schema'
 import { protectedProcedure, publicProcedure, router } from '../init'
+import { getOwnedOrg } from '../owner'
 
 export const organizationRouter = router({
   /**
@@ -65,4 +66,75 @@ export const organizationRouter = router({
       return org
     })
   }),
+
+  /**
+   * Equipe de l'orga gérée par le owner : liste des membres avec leurs infos user.
+   */
+  teamMembers: protectedProcedure.query(async ({ ctx }) => {
+    const org = await getOwnedOrg(ctx)
+
+    const members = await ctx.db.member.findMany({
+      where: { orgId: org.id },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true, image: true } },
+      },
+    })
+
+    return members.map((member) => ({
+      id: member.id,
+      joinedAt: member.createdAt,
+      name: member.user.name,
+      email: member.user.email,
+      image: member.user.image,
+      isOwner: member.user.id === org.ownerId,
+    }))
+  }),
+
+  /**
+   * Retrait d'un membre (owner). Le owner ne peut pas se retirer lui-même ;
+   * refus si le membre a des réservations (intégrité de l'historique).
+   */
+  removeMember: protectedProcedure
+    .input(z.object({ memberId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const org = await getOwnedOrg(ctx)
+
+      const member = await ctx.db.member.findUnique({
+        where: { id: input.memberId },
+        select: { id: true, orgId: true, userId: true },
+      })
+
+      if (!member || member.orgId !== org.id) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Professionnel introuvable.' })
+      }
+
+      if (member.userId === org.ownerId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Le proprietaire ne peut pas etre retire de son organisation.',
+        })
+      }
+
+      const bookingsCount = await ctx.db.booking.count({ where: { memberId: member.id } })
+
+      if (bookingsCount > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Ce professionnel a des reservations, impossible de le retirer.',
+        })
+      }
+
+      // Pas de réservations -> on nettoie ses dépendances puis on le retire.
+      // (MemberService part en cascade via la relation onDelete.)
+      await ctx.db.$transaction(async (tx) => {
+        await tx.review.deleteMany({ where: { memberId: member.id } })
+        await tx.timeSlot.deleteMany({ where: { memberId: member.id } })
+        await tx.member.delete({ where: { id: member.id } })
+      })
+
+      return { memberId: member.id }
+    }),
 })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ enum InvitationStatus {
   PENDING
   ACCEPTED
   REVOKED
+  DECLINED
 }
 
 model Member {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,11 +32,12 @@ model User {
   updatedAt     DateTime @updatedAt
 
   // Relations metier
-  bookings   Booking[]
-  reviews    Review[]
-  rewards    Reward[]
-  ownedOrg   Organization? @relation("OrgOwner")
-  membership Member?
+  bookings        Booking[]
+  reviews         Review[]
+  rewards         Reward[]
+  ownedOrg        Organization?      @relation("OrgOwner")
+  membership      Member?
+  invitationsSent MemberInvitation[] @relation("InvitationsSent")
 
   // Relations BetterAuth (a definir une fois BetterAuth setup)
   sessions Session[]
@@ -120,12 +121,41 @@ model Organization {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  ownerId  String    @unique
-  owner    User      @relation("OrgOwner", fields: [ownerId], references: [id])
-  members  Member[]
-  services Service[]
+  ownerId     String             @unique
+  owner       User               @relation("OrgOwner", fields: [ownerId], references: [id])
+  members     Member[]
+  services    Service[]
+  invitations MemberInvitation[]
 
   @@map("organization")
+}
+
+// Invitation d'un client a rejoindre une orga en tant que membre.
+// Token unique envoye par email ; expire apres INVITATION_TTL_DAYS (cf. lib/invitations/state.ts).
+// "Expiree" se derive de expiresAt (pas de statut stocke), seuls PENDING/ACCEPTED/REVOKED existent.
+model MemberInvitation {
+  id          String           @id @default(cuid())
+  token       String           @unique @default(cuid())
+  email       String
+  orgId       String
+  status      InvitationStatus @default(PENDING)
+  invitedById String
+  expiresAt   DateTime
+  acceptedAt  DateTime?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  invitedBy    User         @relation("InvitationsSent", fields: [invitedById], references: [id], onDelete: Cascade)
+
+  @@index([orgId, status])
+  @@map("member_invitation")
+}
+
+enum InvitationStatus {
+  PENDING
+  ACCEPTED
+  REVOKED
 }
 
 model Member {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -256,9 +256,28 @@ function createPrismaClient() {
 
 async function clearSeedData(prisma: PrismaClient) {
   const userIds = Object.values(seedUsers).map((user) => user.id)
-  const memberIds = Object.values(seedMembers).map((member) => member.id)
   const serviceIds = Object.values(seedServices).map((service) => service.id)
 
+  // Membres rattachés au seed : ids fixes, OU rattachés à l'orga/aux users seed.
+  // Couvre les membres créés dynamiquement par les tests (ex: invitation acceptée).
+  const memberRows = await prisma.member.findMany({
+    where: {
+      OR: [
+        { id: { in: Object.values(seedMembers).map((member) => member.id) } },
+        { orgId: seedOrganization.id },
+        { userId: { in: userIds } },
+      ],
+    },
+    select: { id: true },
+  })
+  const memberIds = memberRows.map((member) => member.id)
+
+  // Invitations d'abord : elles referencent l'orga + le user (sinon FK au moment du delete).
+  await prisma.memberInvitation.deleteMany({
+    where: {
+      OR: [{ orgId: seedOrganization.id }, { invitedById: { in: userIds } }],
+    },
+  })
   await prisma.booking.deleteMany({
     where: {
       OR: [


### PR DESCRIPTION
## Quoi

Sépare la **création d'orga** de l'**adhésion sur invitation**, et ajoute le recrutement de membres côté owner.

## Refactor

- `become-member-form` → renommé `OrganizationCreator`, déplacé dans la page **`/client/create-organization`**.
- Liens « Devenir pro » (navbar publique + sidebar client) → pointent vers `/client/create-organization`.

## Flux invitation

- Modèle Prisma `MemberInvitation` (token, email, orgId, status, expiresAt…) + enum `InvitationStatus`.
- **`/client/become-member?token=XXX`** = acceptation d'invitation (le composant `InvitationAcceptance` gère états valide/expiré/révoqué/mauvais destinataire/déjà membre).
- Token unique, **expire à 7 jours**. Acceptation : user connecté, **même email** que l'invitation, role CLIENT, membre d'aucune orga.

## Recrutement (owner)

- **`/owner/members`** : liste l'équipe + retire un membre (jamais le owner, refus si réservations) + recrute (email d'un **client inscrit non-membre**, sinon refus, on n'envoie rien) + voir/révoquer les invitations en attente + lien copiable.
- Email d'invitation via `sendEmail()` (best-effort), nouveau template React Email.
- Procédures : `invitation.{create,listPending,revoke,accept}`, `organization.{teamMembers,removeMember}` (owner dérivé du contexte, jamais d'orgId client).

## Tests

- Unit : logique pure d'état d'invitation + schéma email.
- Integration : recrutement (éligibilité, doublon), acceptation (+ mauvais destinataire), révocation, retrait de membre (owner protégé, réservations, succès).
- Au vert : typecheck + 51 unit + 47 integration + build.

## Note

`prisma db push` appliqué sur Docker local (jamais Neon). Le modèle `MemberInvitation` devra être poussé en prod via le workflow habituel.