### PR TITLE
feat: sitemap robots og metadata

### DIFF
--- a/app/(public)/[org-slug]/booking/layout.tsx
+++ b/app/(public)/[org-slug]/booking/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+
+// Le tunnel de réservation (choix → créneau → confirmation) repose sur des
+// searchParams non canoniques et n'a aucune valeur SEO. On l'exclut de l'index
+// pour tout le sous-arbre booking d'un coup, plutôt que page par page.
+// `follow: true` laisse les crawlers suivre le lien retour vers la fiche.
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+}
+
+export default function BookingLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/(public)/[org-slug]/opengraph-image.tsx
+++ b/app/(public)/[org-slug]/opengraph-image.tsx
@@ -1,0 +1,27 @@
+import { createCutbookOgImage, OG_CONTENT_TYPE, OG_SIZE } from '@/lib/og/cutbook-og'
+import { getPublicOrganizationMetaBySlug } from '@/lib/organizations/public-organization'
+
+export const alt = 'Réservez votre rendez-vous en ligne sur CutBook'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+
+interface Props {
+  params: Promise<{ 'org-slug': string }>
+}
+
+// Coupe proprement une description trop longue pour ne pas déborder du visuel.
+function truncate(text: string, max = 110) {
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text
+}
+
+export default async function Image({ params }: Props) {
+  const { 'org-slug': orgSlug } = await params
+  const org = await getPublicOrganizationMetaBySlug(orgSlug)
+
+  return createCutbookOgImage({
+    title: org?.name ?? 'Établissement',
+    subtitle: org?.description
+      ? truncate(org.description)
+      : 'Réservez votre rendez-vous en quelques clics.',
+  })
+}

--- a/app/(public)/[org-slug]/page.tsx
+++ b/app/(public)/[org-slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { CalendarDays, ChevronLeft, MapPin, Scissors, User } from 'lucide-react'
 import { notFound } from 'next/navigation'
 import { getPublicOrganizationBySlug } from '@/lib/organizations/public-organization'
-import { getPublicOrgBookingHref } from '@/lib/routes/organization-public-route'
+import { getPublicOrgBookingHref, getPublicOrgHref } from '@/lib/routes/organization-public-route'
 
 interface Props {
   params: Promise<{ 'org-slug': string }>
@@ -11,15 +11,27 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { 'org-slug': orgSlug } = await params
+  // cache() partage cet appel avec le rendu de la page → une seule query DB.
   const org = await getPublicOrganizationBySlug(orgSlug)
 
   if (!org) {
-    return { title: 'Etablissement introuvable - CutBook' }
+    return { title: 'Établissement introuvable', robots: { index: false } }
   }
 
+  const canonicalPath = getPublicOrgHref(org.slug)
+  const description = org.description ?? `Réservez chez ${org.name} en ligne, en quelques clics.`
+
   return {
-    title: `${org.name} - CutBook`,
-    description: org.description ?? `Reservez chez ${org.name} en quelques clics.`,
+    // Le template racine ajoute « | CutBook » → « {nom} | CutBook ».
+    title: org.name,
+    description,
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      type: 'website',
+      url: canonicalPath,
+      title: `${org.name} — CutBook`,
+      description,
+    },
   }
 }
 

--- a/app/(public)/[org-slug]/twitter-image.tsx
+++ b/app/(public)/[org-slug]/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Carte Twitter/X de la page établissement : même image que l'Open Graph.
+export { default, alt, size, contentType } from './opengraph-image'

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -6,14 +6,18 @@ import { HeroSection } from '@/components/layout/hero-section'
 import { HowItWorksSection } from '@/components/layout/how-it-works-section'
 
 export const metadata: Metadata = {
-  title: 'CutBook - Réservation en ligne pour professionnels',
+  // `absolute` court-circuite le template `%s | CutBook` du layout racine :
+  // sur la home on ne veut pas d'un titre redondant « CutBook | CutBook ».
+  title: { absolute: 'CutBook — Réservation en ligne pour coiffeurs, coachs & pros' },
   description:
-    'Réservez en ligne chez votre coiffeur, coach ou esthéticienne. Paiement sécurisé, confirmations automatiques, programme de fidélité.',
+    'Réservez en ligne chez votre coiffeur, coach ou esthéticienne. Booking en temps réel, paiement sécurisé Stripe, confirmations automatiques et programme de fidélité.',
+  alternates: { canonical: '/' },
   openGraph: {
-    title: 'CutBook - Réservation en ligne pour professionnels',
-    description:
-      'Réservez en ligne chez votre coiffeur, coach ou esthéticienne. Paiement sécurisé, confirmations automatiques, programme de fidélité.',
     type: 'website',
+    url: '/',
+    title: 'CutBook — Réservation en ligne pour les pros',
+    description:
+      'Réservez en ligne chez votre coiffeur, coach ou esthéticienne. Paiement sécurisé, confirmations automatiques.',
   },
 }
 

--- a/app/(public)/search/page.tsx
+++ b/app/(public)/search/page.tsx
@@ -5,9 +5,19 @@ import { listPublicOrganizations } from '@/lib/organizations/public-organization
 import { getPublicOrgHref } from '@/lib/routes/organization-public-route'
 
 export const metadata: Metadata = {
-  title: 'Trouver un professionnel - CutBook',
+  // Pas de suffixe manuel : le template `%s | CutBook` du layout racine
+  // ajoute déjà « | CutBook » → « Trouver un professionnel | CutBook ».
+  title: 'Trouver un professionnel',
   description:
-    'Recherchez et reservez chez votre coiffeur, barbier ou estheticien en quelques clics.',
+    'Recherchez et réservez chez votre coiffeur, barbier ou esthéticienne en quelques clics. Disponibilités en temps réel sur CutBook.',
+  alternates: { canonical: '/search' },
+  openGraph: {
+    type: 'website',
+    url: '/search',
+    title: 'Trouver un professionnel — CutBook',
+    description:
+      'Recherchez et réservez chez votre coiffeur, barbier ou esthéticienne en quelques clics.',
+  },
 }
 
 export default async function SearchPage() {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { createCutbookOgImage, OG_CONTENT_TYPE, OG_SIZE } from '@/lib/og/cutbook-og'
+
+// Image OG de marque, héritée par toutes les routes sans override (landing,
+// recherche, pages auth...). Les pages établissement la remplacent par leur
+// propre image dynamique.
+export const alt = 'CutBook — la réservation en ligne pour les pros'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+
+export default async function Image() {
+  return createCutbookOgImage({
+    title: 'Réservez en ligne, en 2 clics',
+    subtitle: 'Coiffeur, coach, esthétique, santé... votre pro disponible en temps réel.',
+  })
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next'
+import { getServerAppUrl } from '@/lib/env'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = getServerAppUrl()
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      // Sections sans contenu indexable : tunnels d'auth + espaces connectés.
+      // Le flow /[slug]/booking, lui, est exclu via un noindex posé sur son
+      // layout — un wildcard milieu-de-path en robots.txt n'est pas fiable
+      // d'un crawler à l'autre.
+      disallow: [
+        '/login',
+        '/register',
+        '/forgot-password',
+        '/reset-password',
+        '/verify-email',
+        '/client',
+        '/member',
+        '/owner',
+        '/admin',
+        '/api/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from 'next'
+import { getServerAppUrl } from '@/lib/env'
+import { listPublicOrganizationsForSitemap } from '@/lib/organizations/public-organization'
+
+// `sitemap.ts` est mis en cache par Next.js par défaut. On le revalide toutes
+// les heures (ISR) pour refléter les nouveaux établissements sans redéployer.
+export const revalidate = 3600
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = getServerAppUrl()
+  const now = new Date()
+
+  // Pages publiques fixes. La landing prime (1.0), la recherche change souvent
+  // (nouveaux salons → daily).
+  // NB: pas de tunnel booking ici (noindex) ni de pages auth/connectées.
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: baseUrl, lastModified: now, changeFrequency: 'weekly', priority: 1 },
+    { url: `${baseUrl}/search`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
+  ]
+
+  // try/catch : le build CI tourne sans DATABASE_URL. Sans ce garde-fou la
+  // génération ISR initiale planterait le build. En prod, la revalidation
+  // horaire injecte les établissements dès que la DB répond.
+  let orgRoutes: MetadataRoute.Sitemap = []
+  try {
+    const organizations = await listPublicOrganizationsForSitemap()
+    orgRoutes = organizations.map((org) => ({
+      url: `${baseUrl}/${org.slug}`,
+      lastModified: org.updatedAt,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }))
+  } catch {
+    orgRoutes = []
+  }
+
+  return [...staticRoutes, ...orgRoutes]
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,3 @@
+// La carte Twitter/X réutilise telle quelle l'image Open Graph (même visuel,
+// mêmes dimensions). On ré-exporte plutôt que de dupliquer le rendu.
+export { default, alt, size, contentType } from './opengraph-image'

--- a/lib/og/cutbook-og.tsx
+++ b/lib/og/cutbook-og.tsx
@@ -1,0 +1,165 @@
+// Générateur d'images Open Graph maison (next/og + Satori).
+//
+// Pourquoi un module partagé : la landing, la recherche et chaque page
+// établissement ont besoin d'une image OG cohérente (même charte Sanzo Wada,
+// même typo Sora). On factorise ici le design, le chargement de font et la
+// taille pour que chaque route `opengraph-image.tsx` ne soit qu'un appel.
+import { ImageResponse } from 'next/og'
+
+// Dimensions standard OG/Twitter (ratio 1.91:1 attendu par Facebook, LinkedIn,
+// X, WhatsApp, iMessage, Slack, Discord...).
+export const OG_SIZE = { width: 1200, height: 630 } as const
+export const OG_CONTENT_TYPE = 'image/png'
+
+// Palette de la charte (cf. .claude/rules/design-system.md). Hors composants
+// React on ne peut pas lire les variables CSS shadcn, donc on duplique les hex
+// ici — c'est le seul endroit autorisé à le faire (rendu serveur Satori).
+const COLORS = {
+  bg: '#f9f7f3',
+  slate: '#253122',
+  green: '#489B6E',
+  gold: '#C5A56E',
+}
+
+// Charge la font Sora depuis Google Fonts pour Satori (qui n'accepte que
+// ttf/otf/woff, jamais woff2). Le param `text` ne sous-charge que les glyphes
+// réellement affichés → payload minimal. En cas d'échec réseau (ex: build CI
+// hors ligne) on renvoie null : ImageResponse retombe alors sur sa font par
+// défaut plutôt que de casser le build.
+async function loadSoraFont(text: string): Promise<ArrayBuffer | null> {
+  try {
+    const url = `https://fonts.googleapis.com/css2?family=Sora:wght@800&text=${encodeURIComponent(text)}`
+    const css = await (await fetch(url)).text()
+    const resource = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)
+
+    if (!resource?.[1]) {
+      return null
+    }
+
+    const fontResponse = await fetch(resource[1])
+    if (!fontResponse.ok) {
+      return null
+    }
+
+    return await fontResponse.arrayBuffer()
+  } catch {
+    return null
+  }
+}
+
+interface CutbookOgImageInput {
+  /** Gros titre (nom de l'établissement ou accroche de la page). */
+  title: string
+  /** Phrase de soutien sous le titre. */
+  subtitle: string
+  /** Surtitre doré en capitales (contexte de la page). */
+  kicker?: string
+}
+
+export async function createCutbookOgImage({
+  title,
+  subtitle,
+  kicker = 'Réservation en ligne',
+}: CutbookOgImageInput) {
+  const fontData = await loadSoraFont(`CutBook${kicker}${title}${subtitle}`)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: COLORS.bg,
+          padding: '72px 80px',
+          fontFamily: 'Sora',
+        }}
+      >
+        {/* En-tête : badge ciseaux + wordmark de marque (toujours "CutBook"). */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 64,
+              height: 64,
+              borderRadius: 18,
+              backgroundColor: COLORS.green,
+            }}
+          >
+            <svg
+              width="34"
+              height="34"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#ffffff"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="6" cy="6" r="3" />
+              <path d="M8.12 8.12 12 12" />
+              <path d="M20 4 8.12 15.88" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M14.8 14.8 20 20" />
+            </svg>
+          </div>
+          <span style={{ fontSize: 34, color: COLORS.slate }}>CutBook</span>
+        </div>
+
+        {/* Corps : surtitre doré, titre principal, sous-titre. */}
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <span
+            style={{
+              fontSize: 22,
+              letterSpacing: 4,
+              textTransform: 'uppercase',
+              color: COLORS.gold,
+              marginBottom: 20,
+            }}
+          >
+            {kicker}
+          </span>
+          <span
+            style={{
+              fontSize: 76,
+              color: COLORS.slate,
+              lineHeight: 1.05,
+              maxWidth: 920,
+            }}
+          >
+            {title}
+          </span>
+          <span
+            style={{
+              fontSize: 30,
+              color: 'rgba(37,49,34,0.6)',
+              marginTop: 24,
+              maxWidth: 820,
+            }}
+          >
+            {subtitle}
+          </span>
+        </div>
+
+        {/* Barre d'accent (60-30-10 : green dominant, gold ponctuel). */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <div style={{ width: 80, height: 8, borderRadius: 99, backgroundColor: COLORS.green }} />
+          <div style={{ width: 28, height: 8, borderRadius: 99, backgroundColor: COLORS.gold }} />
+          <div
+            style={{ width: 14, height: 8, borderRadius: 99, backgroundColor: 'rgba(37,49,34,0.15)' }}
+          />
+        </div>
+      </div>
+    ),
+    {
+      ...OG_SIZE,
+      fonts: fontData
+        ? [{ name: 'Sora', data: fontData, weight: 800 as const, style: 'normal' as const }]
+        : undefined,
+    },
+  )
+}

--- a/lib/organizations/public-organization.ts
+++ b/lib/organizations/public-organization.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { db } from '@/lib/db'
 import { normalizePublicOrgSlug } from '@/lib/routes/organization-public-route'
 import { listPublicSlotDates } from './public-slot-dates'
@@ -23,7 +24,31 @@ export async function listPublicOrganizations() {
   })
 }
 
-export async function getPublicOrganizationBySlug(orgSlug: string) {
+// Query minimale pour le sitemap : on ne charge que ce que `<loc>`/`<lastmod>`
+// exigent. Inutile de remonter services + members comme la query catalogue.
+export async function listPublicOrganizationsForSitemap() {
+  return await db.organization.findMany({
+    select: { slug: true, updatedAt: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+}
+
+// Query minimale pour les metadata SEO + l'image OG : nom, description et
+// updatedAt suffisent. Wrappée dans `cache()` pour que generateMetadata et la
+// route opengraph-image ne tapent pas deux fois la DB sur la même requête.
+export const getPublicOrganizationMetaBySlug = cache(async (orgSlug: string) => {
+  const slug = normalizePublicOrgSlug(orgSlug)
+
+  return await db.organization.findUnique({
+    where: { slug },
+    select: { name: true, description: true, updatedAt: true },
+  })
+})
+
+// `cache()` déduplique l'appel entre generateMetadata et le rendu de la page :
+// Next.js ne mémoize que `fetch()`, jamais Prisma. Sans ça, chaque page org
+// ferait deux fois cette query lourde (services + members) par requête.
+export const getPublicOrganizationBySlug = cache(async (orgSlug: string) => {
   const slug = normalizePublicOrgSlug(orgSlug)
 
   return await db.organization.findUnique({
@@ -48,7 +73,7 @@ export async function getPublicOrganizationBySlug(orgSlug: string) {
       },
     },
   })
-}
+})
 
 interface PublicOrganizationSlotFilters {
   memberId?: string


### PR DESCRIPTION
@
## Objectif

Référencement SEO des **pages publiques** (`/`, `/search`, `/[org-slug]`) et exclusion propre du reste (auth, espaces connectés, tunnel booking). Métadonnées root déjà en place — ici on ajoute le sitemap, le robots, les images OG par page et les meta page-specific.

## Ce qui est ajouté

**Découverte / indexation**
- `app/sitemap.ts` — sitemap dynamique : landing (1.0), `/search` (0.8 daily), **une URL par établissement** (0.7, `lastModified = updatedAt`). **ISR 1h** + `try/catch` (ne casse pas le build sans DB ; les salons sont injectés à la revalidation).
- `app/robots.ts` — `allow: /`, `disallow` sur `(auth)` / `(protected)` / `/api/`, pointe le sitemap + `host`.
- `app/(public)/[org-slug]/booking/layout.tsx` — `noindex, follow` sur tout le tunnel booking (searchParams non canoniques).

**Images Open Graph (next/og)**
- `lib/og/cutbook-og.tsx` — générateur partagé : charte Sanzo Wada + font Sora (chargée depuis Google Fonts, **fallback** si réseau KO).
- `app/opengraph-image.tsx` (+ `twitter-image.tsx` ré-export) — OG de marque, héritée par les pages sans override.
- `app/(public)/[org-slug]/opengraph-image.tsx` (+ `twitter-image.tsx`) — OG **dynamique par salon** (nom + description). Carte texte brandée, pas le logo `imageUrl` (choix assumé).

**Meta page-specific**
- `/`, `/search`, `/[org-slug]` : `openGraph` + `canonical` + titres nettoyés (fix du double `| CutBook`).

**Perf**
- `getPublicOrganizationBySlug` wrappé `cache()` → `generateMetadata` et le rendu partagent **1 seule query** (au lieu de 2). Helpers SEO légers ajoutés (`...ForSitemap`, `...MetaBySlug`).

## Validation

- `typecheck` / `lint` / `build:check` ✓ (pre-push vert).
- `sitemap.xml` et `robots.txt` générés et vérifiés.
- OG = PNG **1200×630** valide (rendu Satori contrôlé visuellement).

## À noter pour la review

- Le `prisma:error` éventuel au build = query org du sitemap quand la DB ne répond pas → **absorbé par le `try/catch`**, voulu.
- Pas de test dédié : sitemap/robots/OG = conventions de fichier Next.js (classées « à ne pas tester » dans `tests.md`).
@