### PR TITLE
feat: add stripe payment flow

### DIFF
--- a/app/(public)/[org-slug]/booking/payment/page.tsx
+++ b/app/(public)/[org-slug]/booking/payment/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { CalendarDays, ChevronLeft, Clock, CreditCard, Scissors, User } from 'lucide-react'
+import { notFound, redirect } from 'next/navigation'
+import { PaymentCheckout } from '@/components/booking/payment-checkout'
+import { getSession } from '@/lib/auth'
+import { getBookingForPayment } from '@/lib/payments/summary'
+
+interface Props {
+  params: Promise<{ 'org-slug': string }>
+  searchParams: Promise<{ booking?: string }>
+}
+
+export const metadata: Metadata = {
+  title: 'Paiement - CutBook',
+}
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' })
+
+export default async function PublicBookingPaymentPage({ params, searchParams }: Props) {
+  const { 'org-slug': orgSlug } = await params
+  const { booking: bookingId } = await searchParams
+
+  // Le booking appartient a un user connecte -> on exige la session.
+  const session = await getSession()
+  if (!session) {
+    redirect(
+      `/login?callbackUrl=${encodeURIComponent(`/${orgSlug}/booking/payment?booking=${bookingId ?? ''}`)}`,
+    )
+  }
+
+  if (!bookingId) {
+    notFound()
+  }
+
+  const booking = await getBookingForPayment(bookingId, session.user.id)
+  if (!booking) {
+    notFound()
+  }
+
+  // Deja paye en ligne -> rien a faire ici.
+  if (booking.payment?.status === 'SUCCEEDED') {
+    redirect('/client/bookings')
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6">
+      {/* Header pleine largeur au-dessus de la grille pour que recap (gauche) et
+          iframe Stripe (droite) demarrent EXACTEMENT au meme niveau vertical. */}
+      <div>
+        <Link
+          href="/client/bookings"
+          className="mb-3 flex items-center gap-1 text-sm transition-opacity hover:opacity-70"
+          style={{ color: 'rgba(37,49,34,0.5)' }}
+        >
+          <ChevronLeft size={14} />
+          Mes reservations
+        </Link>
+        <h1 className="text-xl font-black" style={{ color: '#253122' }}>
+          Paiement
+        </h1>
+        <p className="mt-1 text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
+          Votre rendez-vous est confirme. Reglez en ligne ou payez sur place.
+        </p>
+      </div>
+
+      {/* Recap colonne gauche, iframe colonne droite, alignes au top.
+          Recap reste `sticky top-6` : il se verrouille des que le scroll fait
+          remonter sa position au top-6, et ne bouge plus apres. */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:items-start">
+        <section
+          className="space-y-4 rounded-2xl border p-6 lg:sticky lg:top-6 lg:self-start"
+          style={{ borderColor: 'rgba(37,49,34,0.1)', background: '#fff' }}
+          aria-labelledby="payment-recap-heading"
+        >
+          <h2
+            id="payment-recap-heading"
+            className="text-lg font-black"
+            style={{ color: '#253122' }}
+          >
+            {booking.member.organization.name}
+          </h2>
+          {[
+            {
+              icon: Scissors,
+              label: 'Service',
+              value: `${booking.service.name} - ${booking.service.duration} min`,
+            },
+            { icon: User, label: 'Professionnel', value: booking.member.user.name },
+            {
+              icon: CalendarDays,
+              label: 'Date',
+              value: dateFormatter.format(booking.timeSlot.date),
+            },
+            { icon: Clock, label: 'Heure', value: booking.timeSlot.startTime },
+          ].map(({ icon: Icon, label, value }) => (
+            <div key={label} className="flex items-center gap-3">
+              <Icon size={15} style={{ color: 'rgba(37,49,34,0.4)' }} />
+              <div className="flex flex-1 items-center justify-between gap-4">
+                <span className="text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
+                  {label}
+                </span>
+                <span className="text-right text-sm font-medium" style={{ color: '#253122' }}>
+                  {value}
+                </span>
+              </div>
+            </div>
+          ))}
+          <div
+            className="flex items-center justify-between border-t pt-4"
+            style={{ borderColor: 'rgba(37,49,34,0.08)' }}
+          >
+            <div className="flex items-center gap-2">
+              <CreditCard size={15} style={{ color: '#C5A56E' }} />
+              <span className="text-sm font-semibold" style={{ color: '#253122' }}>
+                A regler
+              </span>
+            </div>
+            <span className="text-xl font-black" style={{ color: '#253122' }}>
+              {booking.totalPrice} EUR
+            </span>
+          </div>
+        </section>
+
+        <div className="space-y-4">
+          <PaymentCheckout bookingId={booking.id} />
+
+          <Link
+            href="/client/bookings"
+            className="block text-center text-sm font-medium transition-opacity hover:opacity-70"
+            style={{ color: 'rgba(37,49,34,0.5)' }}
+          >
+            Payer sur place
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/(public)/[org-slug]/booking/payment/return/page.tsx
+++ b/app/(public)/[org-slug]/booking/payment/return/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation'
+import { getSession } from '@/lib/auth'
+import { confirmCheckoutReturn } from '@/lib/payments/confirm-return'
+
+interface Props {
+  searchParams: Promise<{ session_id?: string }>
+}
+
+// Page de retour apres l'Embedded Checkout (return_url).
+//
+// En prod : le webhook Stripe fait foi et marque deja le paiement comme reussi
+// AVANT que cette page ne soit atteinte. Notre appel a `confirmCheckoutReturn`
+// est alors un no-op (Payment deja SUCCEEDED).
+//
+// En dev sans `stripe listen` operationnel : ce fallback synchrone prend le
+// relais (retrieve la session via API + marque paye via le meme code que le
+// webhook). Idempotent : aucune race possible meme si webhook + retour fusent
+// en parallele.
+//
+// Les erreurs sont silencieuses cote UX : on redirige toujours vers /bookings.
+// Le badge "Paye en ligne" apparait si le paiement a ete confirme (peu importe
+// quel chemin a marque la BDD).
+export default async function PublicBookingPaymentReturnPage({ searchParams }: Props) {
+  const { session_id: sessionId } = await searchParams
+  const session = await getSession()
+
+  if (sessionId && session) {
+    // Best-effort : on tente la confirmation cote serveur. En cas d'echec
+    // (Stripe down, session inconnue, etc.) on swallow et on redirige quand meme.
+    await confirmCheckoutReturn({ sessionId, clientId: session.user.id }).catch(() => null)
+  }
+
+  redirect('/client/bookings')
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,29 @@
+// Webhook Stripe — endpoint public mais VERIFIE par signature.
+// Source de verite du "paye" (cf. lib/payments/webhook.ts).
+//
+// App Router : le body brut est lu via `request.text()` (constructEvent exige
+// le payload non parse pour valider la signature). Pas de bodyParser a desactiver.
+import { env } from '@/lib/env'
+import { handleStripeWebhookEvent } from '@/lib/payments/webhook'
+import { getStripe } from '@/lib/stripe'
+
+export async function POST(request: Request) {
+  const body = await request.text()
+  const signature = request.headers.get('stripe-signature')
+
+  if (!signature || !env.STRIPE_WEBHOOK_SECRET) {
+    return new Response('Missing signature or webhook secret', { status: 400 })
+  }
+
+  let event
+  try {
+    event = getStripe().webhooks.constructEvent(body, signature, env.STRIPE_WEBHOOK_SECRET)
+  } catch {
+    // Signature invalide -> on rejette sans toucher la BDD.
+    return new Response('Invalid signature', { status: 400 })
+  }
+
+  await handleStripeWebhookEvent(event)
+
+  return Response.json({ received: true })
+}

--- a/components/booking/confirm-booking-form.test.tsx
+++ b/components/booking/confirm-booking-form.test.tsx
@@ -17,12 +17,12 @@ vi.mock('@/lib/trpc/client', () => ({
     booking: {
       confirmPublic: {
         useMutation: (options: {
-          onSuccess?: () => void
+          onSuccess?: (data: { bookingId: string }) => void
           onError?: (error: { data?: { code?: string }; message: string }) => void
         }) => {
           return {
             mutate: () => {
-              options?.onSuccess?.()
+              options?.onSuccess?.({ bookingId: 'b1' })
             },
             isPending: false,
           }
@@ -43,7 +43,6 @@ import { ConfirmBookingForm } from './confirm-booking-form'
 describe('ConfirmBookingForm', () => {
   beforeEach(() => {
     routerReplace.mockReset()
-    vi.useFakeTimers()
     window.history.pushState(
       {},
       '',
@@ -51,7 +50,7 @@ describe('ConfirmBookingForm', () => {
     )
   })
 
-  it('redirige vers les reservations client cinq secondes apres confirmation', async () => {
+  it('redirige vers la page de paiement apres confirmation', () => {
     render(
       <ConfirmBookingForm
         orgSlug="atelier-nova"
@@ -65,7 +64,7 @@ describe('ConfirmBookingForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Confirmer la reservation' }))
     expect(screen.getByRole('status')).toHaveTextContent('Reservation confirmee.')
 
-    await vi.advanceTimersByTimeAsync(5000)
-    expect(routerReplace).toHaveBeenCalledWith('/client/bookings')
+    // Paiement optionnel : on enchaine sur l'etape paiement avec le bookingId.
+    expect(routerReplace).toHaveBeenCalledWith('/atelier-nova/booking/payment?booking=b1')
   })
 })

--- a/components/booking/confirm-booking-form.tsx
+++ b/components/booking/confirm-booking-form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { getPublicOrgBookingPaymentHref } from '@/lib/routes/organization-public-route'
 import { trpc } from '@/lib/trpc/client'
 
 interface ConfirmBookingFormProps {
@@ -25,26 +26,15 @@ export function ConfirmBookingForm({
   const router = useRouter()
   const utils = trpc.useUtils()
 
-  useEffect(() => {
-    if (!isConfirmed) {
-      return undefined
-    }
-
-    const timeout = window.setTimeout(() => {
-      router.replace('/client/bookings')
-    }, 5000)
-
-    return () => window.clearTimeout(timeout)
-  }, [isConfirmed, router])
-
   const confirmBooking = trpc.booking.confirmPublic.useMutation({
-    onSuccess() {
-      setOptimisticConfirming(false)
+    onSuccess(data) {
       setIsConfirmed(true)
-      setMessage('Reservation confirmee.')
+      setMessage('Reservation confirmee. Redirection vers le paiement...')
       // Le créneau réservé n'est plus dispo : on invalide la liste pour CE client
       // (utile s'il revient en arrière sur la page de sélection).
       void utils.booking.publicSlots.invalidate()
+      // Paiement optionnel : on enchaine sur l'etape paiement (skippable la-bas).
+      router.replace(getPublicOrgBookingPaymentHref(orgSlug, { booking: data.bookingId }))
     },
     onError(error) {
       setOptimisticConfirming(false)

--- a/components/booking/payment-checkout.tsx
+++ b/components/booking/payment-checkout.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useCallback } from 'react'
+import { EmbeddedCheckout, EmbeddedCheckoutProvider } from '@stripe/react-stripe-js'
+import { getStripeClient } from '@/lib/stripe/client'
+import { trpc } from '@/lib/trpc/client'
+
+interface PaymentCheckoutProps {
+  bookingId: string
+}
+
+export function PaymentCheckout({ bookingId }: PaymentCheckoutProps) {
+  // On passe par le client tRPC "vanilla" (stable entre les renders) pour eviter
+  // de recreer fetchClientSecret et donc de re-initialiser l'Embedded Checkout.
+  const utils = trpc.useUtils()
+
+  const fetchClientSecret = useCallback(async () => {
+    const { clientSecret } = await utils.client.payment.createCheckoutSession.mutate({ bookingId })
+    return clientSecret
+  }, [utils, bookingId])
+
+  return (
+    <div id="checkout" className="overflow-hidden rounded-2xl">
+      <EmbeddedCheckoutProvider stripe={getStripeClient()} options={{ fetchClientSecret }}>
+        <EmbeddedCheckout />
+      </EmbeddedCheckoutProvider>
+    </div>
+  )
+}

--- a/components/dashboard/client-bookings-view.tsx
+++ b/components/dashboard/client-bookings-view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarDays, ChevronRight, Clock, Plus, X } from 'lucide-react'
+import { CalendarDays, ChevronRight, Clock, Plus, Receipt, X } from 'lucide-react'
 import Link from 'next/link'
 import type { BookingStatus } from '@/generated/prisma/enums'
 import { trpc } from '@/lib/trpc/client'
@@ -14,6 +14,8 @@ interface ClientBooking {
   time: string
   price: number
   status: BookingStatus
+  paidOnline: boolean
+  receiptUrl: string | null
 }
 
 const statusLabels: Record<BookingStatus, string> = {
@@ -136,6 +138,14 @@ function ClientBookingsContent({ bookings }: { bookings: ClientBooking[] }) {
                         >
                           {statusLabels[booking.status]}
                         </span>
+                        {booking.paidOnline && (
+                          <span
+                            className="rounded-md px-2 py-0.5 text-xs font-semibold"
+                            style={{ background: 'rgba(72,155,110,0.12)', color: '#489B6E' }}
+                          >
+                            Paye en ligne
+                          </span>
+                        )}
                       </div>
                       <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
                         {booking.service} - {booking.member}
@@ -155,6 +165,18 @@ function ClientBookingsContent({ bookings }: { bookings: ClientBooking[] }) {
                         <span className="font-semibold" style={{ color: '#253122' }}>
                           {booking.price} EUR
                         </span>
+                        {booking.receiptUrl && (
+                          <a
+                            href={booking.receiptUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1 font-medium transition-opacity hover:opacity-70"
+                            style={{ color: '#489B6E' }}
+                          >
+                            <Receipt size={11} />
+                            Recu
+                          </a>
+                        )}
                       </div>
                     </div>
                     {booking.status !== 'CANCELLED' && (

--- a/components/dashboard/client-history-view.tsx
+++ b/components/dashboard/client-history-view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarDays, Clock } from 'lucide-react'
+import { CalendarDays, Clock, Receipt } from 'lucide-react'
 import type { BookingStatus } from '@/generated/prisma/enums'
 import { trpc } from '@/lib/trpc/client'
 
@@ -13,6 +13,8 @@ interface ClientHistoryItem {
   time: string
   price: number
   status: BookingStatus
+  paidOnline: boolean
+  receiptUrl: string | null
 }
 
 const statusStyles = {
@@ -107,6 +109,14 @@ function ClientHistoryContent({ history }: { history: ClientHistoryItem[] }) {
                           >
                             {style.label}
                           </span>
+                          {booking.paidOnline && (
+                            <span
+                              className="rounded-md px-2 py-0.5 text-xs font-semibold"
+                              style={{ background: 'rgba(72,155,110,0.12)', color: '#489B6E' }}
+                            >
+                              Paye en ligne
+                            </span>
+                          )}
                         </div>
                         <p className="mt-0.5 text-sm" style={{ color: 'rgba(37,49,34,0.5)' }}>
                           {booking.service} - {booking.member}
@@ -126,6 +136,18 @@ function ClientHistoryContent({ history }: { history: ClientHistoryItem[] }) {
                           <span className="font-semibold" style={{ color: '#253122' }}>
                             {booking.price} EUR
                           </span>
+                          {booking.receiptUrl && (
+                            <a
+                              href={booking.receiptUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center gap-1 font-medium transition-opacity hover:opacity-70"
+                              style={{ color: '#489B6E' }}
+                            >
+                              <Receipt size={11} />
+                              Recu
+                            </a>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/lib/client/_format.ts
+++ b/lib/client/_format.ts
@@ -1,4 +1,4 @@
-import type { BookingStatus, RewardStatus } from '@/generated/prisma/enums'
+import type { BookingStatus, PaymentStatus, RewardStatus } from '@/generated/prisma/enums'
 
 export interface ClientBookingItem {
   id: string
@@ -9,6 +9,8 @@ export interface ClientBookingItem {
   time: string
   price: number
   status: BookingStatus
+  paidOnline: boolean
+  receiptUrl: string | null
 }
 
 export interface ClientRewardItem {
@@ -37,6 +39,12 @@ type BookingWithDetails = {
     date: Date
     startTime: string
   }
+  // Optionnel : seules les requetes qui incluent `payment` le fournissent
+  // (bookings + history). Les autres (dashboard, member) restent intactes.
+  payment?: {
+    status: PaymentStatus
+    receiptUrl: string | null
+  } | null
 }
 
 const dateFormatter = new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' })
@@ -51,6 +59,8 @@ export function toClientBookingItem(booking: BookingWithDetails): ClientBookingI
     time: booking.timeSlot.startTime,
     price: booking.totalPrice,
     status: booking.status,
+    paidOnline: booking.payment?.status === 'SUCCEEDED',
+    receiptUrl: booking.payment?.receiptUrl ?? null,
   }
 }
 

--- a/lib/client/bookings.ts
+++ b/lib/client/bookings.ts
@@ -28,6 +28,12 @@ const bookingInclude = {
       startTime: true,
     },
   },
+  payment: {
+    select: {
+      status: true,
+      receiptUrl: true,
+    },
+  },
 } as const
 
 export async function getClientUpcomingBookings(clientId: string) {

--- a/lib/payments/checkout.ts
+++ b/lib/payments/checkout.ts
@@ -1,0 +1,108 @@
+// Creation d'une session Stripe Embedded Checkout pour payer un booking.
+//
+// Le paiement est OPTIONNEL : le booking est deja CONFIRMED a la reservation.
+// Ici on cree juste une session de paiement + une ligne Payment (PENDING).
+// Le montant vient TOUJOURS de la BDD (booking.totalPrice), jamais du client.
+import { z } from 'zod'
+import { PaymentStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { getServerAppUrl } from '@/lib/env'
+import { getStripe } from '@/lib/stripe'
+
+export const createBookingCheckoutSchema = z.object({
+  bookingId: z.string().min(1),
+})
+
+export type CreateCheckoutResult =
+  | { ok: true; clientSecret: string }
+  | {
+      ok: false
+      code: 'NOT_FOUND' | 'FORBIDDEN' | 'ALREADY_PAID'
+      message: string
+    }
+
+interface CreateCheckoutInput {
+  bookingId: string
+  clientId: string
+}
+
+export async function createBookingCheckoutSession({
+  bookingId,
+  clientId,
+}: CreateCheckoutInput): Promise<CreateCheckoutResult> {
+  const booking = await db.booking.findUnique({
+    where: { id: bookingId },
+    select: {
+      id: true,
+      clientId: true,
+      totalPrice: true,
+      service: { select: { name: true } },
+      member: { select: { organization: { select: { slug: true } } } },
+      payment: { select: { status: true } },
+    },
+  })
+
+  if (!booking) {
+    return { ok: false, code: 'NOT_FOUND', message: 'Reservation introuvable.' }
+  }
+
+  // Ownership verifie cote serveur : on ne paie que ses propres reservations.
+  if (booking.clientId !== clientId) {
+    return {
+      ok: false,
+      code: 'FORBIDDEN',
+      message: 'Vous ne pouvez pas payer cette reservation.',
+    }
+  }
+
+  if (booking.payment?.status === PaymentStatus.SUCCEEDED) {
+    return { ok: false, code: 'ALREADY_PAID', message: 'Cette reservation est deja payee.' }
+  }
+
+  const slug = booking.member.organization.slug
+  // totalPrice est un Float (euros) -> Stripe attend des centimes entiers.
+  const unitAmount = Math.round(booking.totalPrice * 100)
+
+  const session = await getStripe().checkout.sessions.create({
+    // stripe v22 : la valeur "embedded" s'appelle desormais "embedded_page"
+    // (le client_secret reste compatible avec @stripe/react-stripe-js EmbeddedCheckout).
+    ui_mode: 'embedded_page',
+    mode: 'payment',
+    line_items: [
+      {
+        price_data: {
+          currency: 'eur',
+          product_data: { name: booking.service.name },
+          unit_amount: unitAmount,
+        },
+        quantity: 1,
+      },
+    ],
+    // metadata.bookingId : relu par le webhook pour rattacher le paiement.
+    metadata: { bookingId: booking.id },
+    return_url: `${getServerAppUrl()}/${slug}/booking/payment/return?session_id={CHECKOUT_SESSION_ID}`,
+  })
+
+  if (!session.client_secret) {
+    return { ok: false, code: 'NOT_FOUND', message: 'Session de paiement invalide.' }
+  }
+
+  // Upsert : si le client relance un paiement (retry), on reutilise la ligne.
+  await db.payment.upsert({
+    where: { bookingId: booking.id },
+    create: {
+      bookingId: booking.id,
+      amount: booking.totalPrice,
+      currency: 'eur',
+      status: PaymentStatus.PENDING,
+      stripeSessionId: session.id,
+    },
+    update: {
+      amount: booking.totalPrice,
+      status: PaymentStatus.PENDING,
+      stripeSessionId: session.id,
+    },
+  })
+
+  return { ok: true, clientSecret: session.client_secret }
+}

--- a/lib/payments/confirm-return.ts
+++ b/lib/payments/confirm-return.ts
@@ -1,0 +1,95 @@
+// Validation cote serveur d'un retour de Checkout (page /return apres paiement).
+//
+// Pourquoi ce module en plus du webhook : en prod, le webhook Stripe est seul
+// juge du "paye" (cf. webhook.ts). Mais en local, le `stripe listen` du CLI
+// peut etre indisponible (firewall, WebSocket coupe sur Windows, etc.), et
+// l'event n'arrive jamais. Ce fallback synchrone, declenche par la page de
+// retour cote serveur, retrouve la session via l'API Stripe et marque le
+// paiement comme reussi via le MEME `markBookingPaid` que le webhook.
+//
+// Idempotent et SAFE en prod : si le webhook a deja marque SUCCEEDED en premier,
+// `markBookingPaid` no-op. Sinon ce fallback prend le relais. La verification
+// reste ancree dans Stripe (on retrieve la session) et l'ownership est verifie
+// en BDD avant tout marquage.
+import type Stripe from 'stripe'
+import { PaymentStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { getStripe } from '@/lib/stripe'
+import { markBookingPaid } from './webhook'
+
+export type ConfirmCheckoutReturnResult =
+  | { ok: true; alreadyPaid: boolean }
+  | { ok: false; code: 'NOT_FOUND' | 'FORBIDDEN' | 'NOT_PAID' | 'STRIPE_ERROR' }
+
+interface ConfirmCheckoutReturnInput {
+  sessionId: string
+  clientId: string
+}
+
+export async function confirmCheckoutReturn({
+  sessionId,
+  clientId,
+}: ConfirmCheckoutReturnInput): Promise<ConfirmCheckoutReturnResult> {
+  // 1. Retrouver le Payment correspondant en BDD (+ ownership via booking.clientId).
+  const payment = await db.payment.findUnique({
+    where: { stripeSessionId: sessionId },
+    select: {
+      id: true,
+      status: true,
+      booking: { select: { clientId: true } },
+    },
+  })
+
+  if (!payment) {
+    return { ok: false, code: 'NOT_FOUND' }
+  }
+
+  if (payment.booking.clientId !== clientId) {
+    return { ok: false, code: 'FORBIDDEN' }
+  }
+
+  // Webhook deja passe -> no-op silencieux, succes.
+  if (payment.status === PaymentStatus.SUCCEEDED) {
+    return { ok: true, alreadyPaid: true }
+  }
+
+  // 2. Retrieve la session cote Stripe pour verifier l'etat reel du paiement.
+  //    On expand `payment_intent.latest_charge` pour recuperer le recu en une
+  //    seule requete.
+  let session: Stripe.Checkout.Session
+  try {
+    session = await getStripe().checkout.sessions.retrieve(sessionId, {
+      expand: ['payment_intent.latest_charge'],
+    })
+  } catch {
+    return { ok: false, code: 'STRIPE_ERROR' }
+  }
+
+  if (session.payment_status !== 'paid' || session.status !== 'complete') {
+    return { ok: false, code: 'NOT_PAID' }
+  }
+
+  // 3. Extraire le PaymentIntent id + URL du recu (via latest_charge expanded).
+  const paymentIntent = session.payment_intent
+  let paymentIntentId: string | null = null
+  let receiptUrl: string | null = null
+
+  if (typeof paymentIntent === 'string') {
+    paymentIntentId = paymentIntent
+  } else if (paymentIntent) {
+    paymentIntentId = paymentIntent.id
+    const charge = paymentIntent.latest_charge
+    if (charge && typeof charge !== 'string') {
+      receiptUrl = charge.receipt_url ?? null
+    }
+  }
+
+  if (!paymentIntentId) {
+    return { ok: false, code: 'NOT_PAID' }
+  }
+
+  // 4. Marque comme paye via le MEME chemin que le webhook (idempotent).
+  await markBookingPaid({ sessionId, paymentIntentId, receiptUrl })
+
+  return { ok: true, alreadyPaid: false }
+}

--- a/lib/payments/payment.integration.test.ts
+++ b/lib/payments/payment.integration.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+
+import 'dotenv/config'
+
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { runSeed, seedUsers } from '@/prisma/seed'
+import { db } from '@/lib/db'
+
+// On mocke Stripe : pas d'appel reseau ni de cle requise. `sessions.create`
+// renvoie un faux clientSecret ; `sessions.retrieve` est utilise par le
+// fallback /return pour valider l'etat reel de la session paiement.
+const { sessionsCreate, sessionsRetrieve } = vi.hoisted(() => ({
+  sessionsCreate: vi.fn(),
+  sessionsRetrieve: vi.fn(),
+}))
+
+vi.mock('@/lib/stripe', () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: sessionsCreate, retrieve: sessionsRetrieve } },
+  }),
+}))
+
+import { createBookingCheckoutSession } from '@/lib/payments/checkout'
+import { confirmCheckoutReturn } from '@/lib/payments/confirm-return'
+import { markBookingPaid } from '@/lib/payments/webhook'
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL is required to run integration tests')
+}
+
+// Booking du seed : clientOne, service "cut" a 55 EUR, statut CONFIRMED.
+const BOOKING_ID = 'seed-booking-confirmed'
+
+describe('payments', () => {
+  beforeAll(async () => {
+    await runSeed()
+    sessionsCreate.mockResolvedValue({ id: 'cs_test_x', client_secret: 'sec_x' })
+  })
+
+  it('refuse de payer la reservation d un autre client', async () => {
+    const result = await createBookingCheckoutSession({
+      bookingId: BOOKING_ID,
+      clientId: seedUsers.clientTwo.id,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: 'FORBIDDEN' })
+  })
+
+  it('refuse une reservation introuvable', async () => {
+    const result = await createBookingCheckoutSession({
+      bookingId: 'does-not-exist',
+      clientId: seedUsers.clientOne.id,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: 'NOT_FOUND' })
+  })
+
+  it('cree un Payment PENDING avec le montant de la BDD (jamais du client)', async () => {
+    const result = await createBookingCheckoutSession({
+      bookingId: BOOKING_ID,
+      clientId: seedUsers.clientOne.id,
+    })
+
+    expect(result).toEqual({ ok: true, clientSecret: 'sec_x' })
+
+    // Montant envoye a Stripe = totalPrice (55 EUR) en centimes.
+    expect(sessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ui_mode: 'embedded_page',
+        mode: 'payment',
+        line_items: [
+          expect.objectContaining({
+            price_data: expect.objectContaining({ unit_amount: 5500 }),
+          }),
+        ],
+      }),
+    )
+
+    const payment = await db.payment.findUnique({ where: { bookingId: BOOKING_ID } })
+    expect(payment?.status).toBe('PENDING')
+    expect(payment?.amount).toBe(55)
+    expect(payment?.stripeSessionId).toBe('cs_test_x')
+  })
+
+  it('marque le paiement reussi et reporte le PaymentIntent sur le booking', async () => {
+    await markBookingPaid({
+      sessionId: 'cs_test_x',
+      paymentIntentId: 'pi_test_1',
+      receiptUrl: 'https://stripe.test/receipt',
+    })
+
+    const payment = await db.payment.findUnique({ where: { bookingId: BOOKING_ID } })
+    expect(payment?.status).toBe('SUCCEEDED')
+    expect(payment?.stripePaymentIntentId).toBe('pi_test_1')
+    expect(payment?.paidAt).toBeInstanceOf(Date)
+
+    const booking = await db.booking.findUnique({ where: { id: BOOKING_ID } })
+    expect(booking?.stripePaymentId).toBe('pi_test_1')
+  })
+
+  it('refuse un second paiement si la reservation est deja payee', async () => {
+    const result = await createBookingCheckoutSession({
+      bookingId: BOOKING_ID,
+      clientId: seedUsers.clientOne.id,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: 'ALREADY_PAID' })
+  })
+
+  it('est idempotent : un second webhook ne change rien', async () => {
+    await markBookingPaid({
+      sessionId: 'cs_test_x',
+      paymentIntentId: 'pi_test_2_different',
+      receiptUrl: 'https://stripe.test/other',
+    })
+
+    const payment = await db.payment.findUnique({ where: { bookingId: BOOKING_ID } })
+    // Toujours le 1er PaymentIntent : le 2e appel est ignore.
+    expect(payment?.stripePaymentIntentId).toBe('pi_test_1')
+  })
+
+  // === Fallback confirmCheckoutReturn (page /return) ===
+  // En prod : le webhook fait foi et ce fallback est un no-op idempotent.
+  // En dev sans `stripe listen` actif : ce fallback prend le relais et marque
+  // payé en interrogeant directement l'API Stripe.
+
+  it('confirmReturn : refuse si la session est inconnue', async () => {
+    sessionsRetrieve.mockClear()
+    const result = await confirmCheckoutReturn({
+      sessionId: 'cs_unknown_xyz',
+      clientId: seedUsers.clientOne.id,
+    })
+    expect(result).toEqual({ ok: false, code: 'NOT_FOUND' })
+    // Court-circuit avant tout appel reseau Stripe.
+    expect(sessionsRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('confirmReturn : refuse si la session appartient a un autre client', async () => {
+    sessionsRetrieve.mockClear()
+    // cs_test_x est lie a seed-booking-confirmed (clientOne).
+    const result = await confirmCheckoutReturn({
+      sessionId: 'cs_test_x',
+      clientId: seedUsers.clientTwo.id,
+    })
+    expect(result).toEqual({ ok: false, code: 'FORBIDDEN' })
+    expect(sessionsRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('confirmReturn : no-op idempotent si Payment deja SUCCEEDED (le webhook a gagne)', async () => {
+    sessionsRetrieve.mockClear()
+    const result = await confirmCheckoutReturn({
+      sessionId: 'cs_test_x',
+      clientId: seedUsers.clientOne.id,
+    })
+    expect(result).toEqual({ ok: true, alreadyPaid: true })
+    // Court-circuit : pas besoin d'interroger Stripe si la BDD dit deja SUCCEEDED.
+    expect(sessionsRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('confirmReturn : marque paye via Stripe API si webhook n a pas fire', async () => {
+    // Setup : un Payment PENDING tout frais sur seed-booking-completed (clientTwo).
+    await db.payment.create({
+      data: {
+        bookingId: 'seed-booking-completed',
+        amount: 42,
+        currency: 'eur',
+        status: 'PENDING',
+        stripeSessionId: 'cs_return_fresh',
+      },
+    })
+
+    // Stripe retourne une session payee avec un PI + recu (cas du happy path en dev).
+    sessionsRetrieve.mockResolvedValueOnce({
+      id: 'cs_return_fresh',
+      payment_status: 'paid',
+      status: 'complete',
+      payment_intent: {
+        id: 'pi_return_fresh',
+        latest_charge: { receipt_url: 'https://stripe.test/return-receipt' },
+      },
+    })
+
+    const result = await confirmCheckoutReturn({
+      sessionId: 'cs_return_fresh',
+      clientId: seedUsers.clientTwo.id,
+    })
+
+    expect(result).toEqual({ ok: true, alreadyPaid: false })
+
+    const payment = await db.payment.findUnique({ where: { stripeSessionId: 'cs_return_fresh' } })
+    expect(payment?.status).toBe('SUCCEEDED')
+    expect(payment?.stripePaymentIntentId).toBe('pi_return_fresh')
+    expect(payment?.receiptUrl).toBe('https://stripe.test/return-receipt')
+
+    const booking = await db.booking.findUnique({ where: { id: 'seed-booking-completed' } })
+    expect(booking?.stripePaymentId).toBe('pi_return_fresh')
+  })
+})

--- a/lib/payments/summary.ts
+++ b/lib/payments/summary.ts
@@ -1,0 +1,30 @@
+// Lecture d'un booking en vue de son paiement (page paiement, shell serveur).
+// Verifie l'ownership : retourne null si le booking n'existe pas ou n'appartient
+// pas au client connecte -> la page repond notFound().
+import { db } from '@/lib/db'
+
+export async function getBookingForPayment(bookingId: string, clientId: string) {
+  const booking = await db.booking.findUnique({
+    where: { id: bookingId },
+    select: {
+      id: true,
+      clientId: true,
+      totalPrice: true,
+      service: { select: { name: true, duration: true } },
+      member: {
+        select: {
+          user: { select: { name: true } },
+          organization: { select: { name: true, slug: true } },
+        },
+      },
+      timeSlot: { select: { date: true, startTime: true } },
+      payment: { select: { status: true } },
+    },
+  })
+
+  if (!booking || booking.clientId !== clientId) {
+    return null
+  }
+
+  return booking
+}

--- a/lib/payments/webhook.ts
+++ b/lib/payments/webhook.ts
@@ -1,0 +1,89 @@
+// Traitement des webhooks Stripe — SOURCE DE VERITE du "paye".
+//
+// Le return_url cote client est asynchrone et non fiable : seul le webhook
+// (signature deja verifiee dans la route) marque un paiement comme reussi.
+// Regle security.md : pas de logique metier ici, juste marquer paye, idempotent.
+import type Stripe from 'stripe'
+import { PaymentStatus } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { getStripe } from '@/lib/stripe'
+
+interface MarkBookingPaidInput {
+  sessionId: string
+  paymentIntentId: string
+  receiptUrl: string | null
+}
+
+// Marque le Payment SUCCEEDED + reporte l'id PaymentIntent sur le Booking.
+// Idempotent : un 2e appel (Stripe peut renvoyer un event) ne fait rien.
+export async function markBookingPaid({
+  sessionId,
+  paymentIntentId,
+  receiptUrl,
+}: MarkBookingPaidInput) {
+  const payment = await db.payment.findUnique({
+    where: { stripeSessionId: sessionId },
+    select: { id: true, bookingId: true, status: true },
+  })
+
+  // Session inconnue (creee hors de notre flow) ou deja traitee -> no-op.
+  if (!payment || payment.status === PaymentStatus.SUCCEEDED) {
+    return
+  }
+
+  await db.$transaction([
+    db.payment.update({
+      where: { id: payment.id },
+      data: {
+        status: PaymentStatus.SUCCEEDED,
+        stripePaymentIntentId: paymentIntentId,
+        receiptUrl,
+        paidAt: new Date(),
+      },
+    }),
+    db.booking.update({
+      where: { id: payment.bookingId },
+      data: { stripePaymentId: paymentIntentId },
+    }),
+  ])
+}
+
+// Dispatch d'un event Stripe deja verifie. On ne traite que la fin de paiement.
+export async function handleStripeWebhookEvent(event: Stripe.Event) {
+  if (event.type !== 'checkout.session.completed') {
+    return
+  }
+
+  const session = event.data.object
+  if (session.mode !== 'payment' || session.payment_status !== 'paid') {
+    return
+  }
+
+  const paymentIntentId =
+    typeof session.payment_intent === 'string' ? session.payment_intent : session.payment_intent?.id
+
+  if (!paymentIntentId) {
+    return
+  }
+
+  // L'URL du recu est un nice-to-have : si la recuperation echoue (PI introuvable
+  // sur les events de test `stripe trigger`, ou tout autre erreur reseau Stripe),
+  // on marque QUAND MEME le paiement comme reussi, juste sans recu. Le marquage
+  // "paye" est l'info critique ; sans ce try/catch, une 404 sur le PI ferait
+  // crasher tout le webhook (return 500) et le booking ne serait jamais paye.
+  let receiptUrl: string | null = null
+  try {
+    const paymentIntent = await getStripe().paymentIntents.retrieve(paymentIntentId, {
+      expand: ['latest_charge'],
+    })
+    const charge = paymentIntent.latest_charge
+    if (charge && typeof charge !== 'string') {
+      receiptUrl = charge.receipt_url ?? null
+    }
+  } catch (error) {
+    // On log mais on n'arrete pas le flow : le booking sera marque paye sans recu.
+    console.warn('[stripe webhook] recu non recuperable pour PI', paymentIntentId, error)
+  }
+
+  await markBookingPaid({ sessionId: session.id, paymentIntentId, receiptUrl })
+}

--- a/lib/routes/organization-public-route.ts
+++ b/lib/routes/organization-public-route.ts
@@ -36,3 +36,7 @@ export function getPublicOrgBookingSlotHref(orgSlug: string, search?: RouteSearc
 export function getPublicOrgBookingConfirmHref(orgSlug: string, search?: RouteSearch) {
   return `${getPublicOrgBookingHref(orgSlug)}/confirm${formatSearchSuffix(search)}`
 }
+
+export function getPublicOrgBookingPaymentHref(orgSlug: string, search?: RouteSearch) {
+  return `${getPublicOrgBookingHref(orgSlug)}/payment${formatSearchSuffix(search)}`
+}

--- a/lib/stripe/client.ts
+++ b/lib/stripe/client.ts
@@ -1,0 +1,18 @@
+'use client'
+
+// Stripe.js cote NAVIGATEUR (singleton). Module client du pattern lib/stripe.
+//
+// `loadStripe` doit etre appele hors du render d'un composant pour ne pas
+// recreer l'objet Stripe a chaque rendu. On memoise donc la promesse une fois.
+import { loadStripe, type Stripe } from '@stripe/stripe-js'
+import { env } from '@/lib/env'
+
+let stripePromise: Promise<Stripe | null> | undefined
+
+export function getStripeClient() {
+  if (!stripePromise) {
+    stripePromise = loadStripe(env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '')
+  }
+
+  return stripePromise
+}

--- a/lib/stripe/index.ts
+++ b/lib/stripe/index.ts
@@ -1,0 +1,24 @@
+// Client Stripe SERVEUR (singleton). INTERNE au module lib/stripe.
+// A importer uniquement cote serveur (tRPC, route handler webhook) — jamais client.
+//
+// Pourquoi lazy (getStripe) plutot qu'un export top-level comme lib/db :
+// `next build` evalue le top-level des route handlers. Instancier Stripe au
+// chargement du module ferait crasher le build si STRIPE_SECRET_KEY est absente
+// (ex: build:check avec SKIP_ENV_VALIDATION). On differe donc l'init au 1er appel.
+import Stripe from 'stripe'
+import { env } from '@/lib/env'
+
+let cached: Stripe | undefined
+
+export function getStripe(): Stripe {
+  if (cached) {
+    return cached
+  }
+
+  if (!env.STRIPE_SECRET_KEY) {
+    throw new Error('STRIPE_SECRET_KEY is required to use Stripe')
+  }
+
+  cached = new Stripe(env.STRIPE_SECRET_KEY)
+  return cached
+}

--- a/lib/trpc/routers/index.ts
+++ b/lib/trpc/routers/index.ts
@@ -7,6 +7,7 @@ import { clientRouter } from './client'
 import { invitationRouter } from './invitation'
 import { memberRouter } from './member'
 import { organizationRouter } from './organization'
+import { paymentRouter } from './payment'
 import { serviceRouter } from './service'
 import { timeSlotRouter } from './time-slot'
 
@@ -14,6 +15,7 @@ export const appRouter = router({
   admin: adminRouter,
   organization: organizationRouter,
   booking: bookingRouter,
+  payment: paymentRouter,
   service: serviceRouter,
   timeSlot: timeSlotRouter,
   invitation: invitationRouter,

--- a/lib/trpc/routers/payment.ts
+++ b/lib/trpc/routers/payment.ts
@@ -1,0 +1,32 @@
+// Router tRPC pour les paiements Stripe.
+import { TRPCError } from '@trpc/server'
+import { createBookingCheckoutSchema, createBookingCheckoutSession } from '@/lib/payments/checkout'
+import { protectedProcedure, router } from '../init'
+
+export const paymentRouter = router({
+  // Cree une session Embedded Checkout pour le booking et renvoie le clientSecret.
+  // protectedProcedure : il faut etre connecte, et l'ownership est verifie en BDD.
+  createCheckoutSession: protectedProcedure
+    .input(createBookingCheckoutSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await createBookingCheckoutSession({
+        bookingId: input.bookingId,
+        clientId: ctx.user.id,
+      })
+
+      if (result.ok) {
+        return { clientSecret: result.clientSecret }
+      }
+
+      if (result.code === 'NOT_FOUND') {
+        throw new TRPCError({ code: 'NOT_FOUND', message: result.message })
+      }
+
+      if (result.code === 'FORBIDDEN') {
+        throw new TRPCError({ code: 'FORBIDDEN', message: result.message })
+      }
+
+      // ALREADY_PAID
+      throw new TRPCError({ code: 'BAD_REQUEST', message: result.message })
+    }),
+})

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@prisma/client": "^7.8.0",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
+    "@stripe/react-stripe-js": "^6.4.0",
+    "@stripe/stripe-js": "^9.7.0",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-table": "^8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       '@react-email/render':
         specifier: ^2.0.8
         version: 2.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stripe/react-stripe-js':
+        specifier: ^6.4.0
+        version: 6.4.0(@stripe/stripe-js@9.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stripe/stripe-js':
+        specifier: ^9.7.0
+        version: 9.7.0
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -2400,6 +2406,17 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stripe/react-stripe-js@6.4.0':
+    resolution: {integrity: sha512-5cAf7GAqf8VHPoPLVnJQ2MHtDWLdiEPs5GW/loU7iDEue3xf620v11skrk5HICUraDOhODPYpttgFC5N579NxA==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=9.5.0 <10.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@9.7.0':
+    resolution: {integrity: sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==}
+    engines: {node: '>=12.16'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -8317,6 +8334,15 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stripe/react-stripe-js@6.4.0(@stripe/stripe-js@9.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@stripe/stripe-js': 9.7.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@stripe/stripe-js@9.7.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -254,6 +254,7 @@ model Booking {
   member   Member   @relation(fields: [memberId], references: [id])
   service  Service  @relation(fields: [serviceId], references: [id])
   timeSlot TimeSlot @relation(fields: [timeSlotId], references: [id])
+  payment  Payment?
 
   @@map("booking")
 }
@@ -263,6 +264,38 @@ enum BookingStatus {
   CONFIRMED
   COMPLETED
   CANCELLED
+}
+
+// =============================================================
+// PAIEMENTS Stripe
+// Paiement en ligne OPTIONNEL : le booking est deja CONFIRMED a la
+// reservation, le Payment est une couche additive. 1 booking -> au plus
+// 1 paiement (bookingId @unique) ; on upsert sur les retries.
+// Source de verite du "paye" = le webhook Stripe (jamais le return_url).
+// =============================================================
+
+model Payment {
+  id                    String        @id @default(cuid())
+  bookingId             String        @unique
+  amount                Float
+  currency              String        @default("eur")
+  status                PaymentStatus @default(PENDING)
+  stripeSessionId       String?       @unique
+  stripePaymentIntentId String?       @unique
+  receiptUrl            String?
+  paidAt                DateTime?
+  createdAt             DateTime      @default(now())
+  updatedAt             DateTime      @updatedAt
+
+  booking Booking @relation(fields: [bookingId], references: [id], onDelete: Cascade)
+
+  @@map("payment")
+}
+
+enum PaymentStatus {
+  PENDING
+  SUCCEEDED
+  FAILED
 }
 
 // =============================================================


### PR DESCRIPTION
## Ce que ca apporte

Etape de paiement Stripe Embedded Checkout (mode test) inseree entre le recap booking et la liste des RDV. **Paiement optionnel** : le RDV est cree CONFIRMED a la confirmation classique (logique inchangee), le paiement Stripe est une couche additive — le client peut 'Payer sur place'.

## Architecture

- **Embedded Checkout** (`@stripe/react-stripe-js`) avec `ui_mode: 'embedded_page'` (renomme dans stripe v22).
- Modele `Payment` dedie en BDD (1:1 booking, upsert sur retry).
- **Webhook = source de verite** (`app/api/stripe/webhook/route.ts`, signature verifiee, idempotent).
- **Fallback sync via la page `/return`** : retrieve la session via API Stripe et marque paye meme si le webhook n'arrive pas (utile en dev local sans `stripe listen` operationnel). Idempotent avec le webhook.
- Page paiement : layout 2 colonnes (recap sticky a gauche / iframe Stripe a droite, stack sur mobile).
- Badge **'Paye en ligne'** + lien recu Stripe officiel sur `/client/bookings` ET `/client/history`.

## Tests

- 10 tests d'integration (`lib/payments/payment.integration.test.ts`) couvrant : ownership, deja paye, montant BDD (jamais du client), idempotence webhook, fallback /return (NOT_FOUND / FORBIDDEN / idempotent / happy path).
- `confirm-booking-form.test.tsx` mis a jour pour la redirection vers la page paiement.

## Setup local

1. Ajouter dans `.env` : `STRIPE_SECRET_KEY=sk_test_...`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...`, `STRIPE_WEBHOOK_SECRET=whsec_...`
2. `pnpm db:push` (le modele `Payment` est nouveau)
3. (Optionnel) `stripe listen --forward-to localhost:3000/api/stripe/webhook` pour le webhook. Si le CLI Stripe est instable sur ta machine, le fallback `/return` prend le relais.
4. `pnpm dev` puis carte test `4242 4242 4242 4242`.

## TODO post-merge (avec `feat/booking-emails`)

Cabler `sendPaymentReceiptEmail` dans `markBookingPaid` une fois les deux branches mergees sur `dev` — hors scope ici (le module email vit sur l'autre branche).