### PR TITLE
refactor: specialize member catalogs

### DIFF
--- a/lib/organizations/public-organization.integration.test.ts
+++ b/lib/organizations/public-organization.integration.test.ts
@@ -155,13 +155,12 @@ describe('public organization data', () => {
       }),
     ).resolves.toBeNull()
 
-    // Incoherence service / orga : on prend un service rattache a une autre
-    // organisation (Refuge) avec un slot Nova. Le seed rich attache toutes
-    // les prestations Nova a Leo, donc on ne peut plus utiliser un service
-    // Nova pour declencher la nullite ici.
+    // Incoherence service / membre intra-org : Leo est specialise barbe et ne
+    // propose pas cut, donc le recapitulatif doit retourner null meme si tout
+    // le reste (orga, slot, member) est coherent.
     await expect(
       getPublicBookingConfirmationSummary(seedOrganization.slug, {
-        serviceId: 'seed-service-barbershop-le-refuge-classic',
+        serviceId: seedServices.cut.id,
         memberId: seedMembers.leo.id,
         slotId: 'seed-slot-leo-2',
       }),

--- a/lib/trpc/routers/booking.integration.test.ts
+++ b/lib/trpc/routers/booking.integration.test.ts
@@ -72,13 +72,13 @@ describe('bookingRouter', () => {
   })
 
   it('ne renvoie aucun creneau pour un service que le membre ne propose pas', async () => {
-    // Le seed rich attache toutes les prestations Nova a Mila et Leo, donc on
-    // teste l'invariant avec un service d'une AUTRE orga : Mila ne fait pas
-    // les services Refuge -> le filtre member-service doit retourner 0.
+    // Intra-org : Mila est specialisee femme/couleur (cut + color), donc ne
+    // propose pas beard meme si c'est un service de son propre salon. Le filtre
+    // member-service doit retourner 0 creneaux.
     const result = await publicCaller.booking.publicSlots({
       orgSlug: seedOrganization.slug,
       memberId: seedMembers.mila.id,
-      serviceId: 'seed-service-barbershop-le-refuge-classic',
+      serviceId: seedServices.beard.id,
     })
 
     expect(result.slots).toHaveLength(0)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1259,21 +1259,36 @@ async function seedRichContent(prisma: PrismaClient, passwordHash: string) {
   }))
   await prisma.service.createMany({ data: novaExtraServices })
 
-  // MemberService : chaque membre fait tous les services de son orga (simplification demo)
+  // MemberService : chaque membre a son catalogue specialise (plus realiste
+  // qu'un salon ou tout le monde fait tout), et indispensable pour preserver
+  // l'invariant intra-org utilise par les tests d'integration
+  // ("service non propose par le membre") :
+  //   - Nora       : 3 prestations historiques (geante polyvalente, cumule owner+member)
+  //   - Mila       : cut + color uniquement (specialiste femme/couleur)
+  //   - Leo        : beard uniquement (specialiste homme/barbe)
+  //   - Hugo/Yasmine (extras) : portent les nouvelles prestations Nova (Olaplex, Permanente, etc.)
   type MemberCatalog = { id: string; orgId: string; serviceIds: string[] }
-  const novaServiceIds = [
-    seedServices.cut.id,
-    seedServices.color.id,
-    seedServices.beard.id,
-    ...novaExtraServices.map((s) => s.id),
-  ]
+  const novaExtraServiceIds = novaExtraServices.map((s) => s.id)
   const memberCatalogs: MemberCatalog[] = [
-    { id: seedMembers.mila.id, orgId: seedOrganization.id, serviceIds: novaServiceIds },
-    { id: seedMembers.leo.id, orgId: seedOrganization.id, serviceIds: novaServiceIds },
+    {
+      id: seedMembers.nora.id,
+      orgId: seedOrganization.id,
+      serviceIds: [seedServices.cut.id, seedServices.color.id, seedServices.beard.id],
+    },
+    {
+      id: seedMembers.mila.id,
+      orgId: seedOrganization.id,
+      serviceIds: [seedServices.cut.id, seedServices.color.id],
+    },
+    {
+      id: seedMembers.leo.id,
+      orgId: seedOrganization.id,
+      serviceIds: [seedServices.beard.id],
+    },
     ...novaExtraMembers.map((m) => ({
       id: m.id,
       orgId: seedOrganization.id,
-      serviceIds: novaServiceIds,
+      serviceIds: novaExtraServiceIds,
     })),
     ...extraPlans.flatMap((plan) =>
       plan.members.map((m) => ({


### PR DESCRIPTION
## Objectif

Restaurer la couverture intra-org des tests d'integration qui avait ete contournee dans la PR #41 (workarounds cross-org avec un service Refuge), tout en rendant le seed plus realiste.

## Probleme

La PR #41 (rich seed) avait force Mila et Leo a etre polyvalents sur les 8 services Nova via `memberCatalogs` dans `seedRichContent`. Resultat : impossible de tester l'invariant intra-org "un membre ne propose pas tel service de SA propre orga" → 2 tests d'integration avaient ete adaptes pour utiliser un service de l'orga Refuge (cross-org workaround).

Risques de ce workaround :
1. Test devenu cross-org au lieu d'intra-org : ne couvre plus l'intent metier reel
2. Faux positif silencieux possible : si le slug `barbershop-le-refuge` change un jour, le `serviceId` n'existe plus → le test retourne 0 par hasard, pas par filtre

## Solution

### Cote seed (`prisma/seed.ts`)

Specialiser les catalogues de members Nova dans `seedRichContent` au lieu de tout donner a tout le monde :

| Member | Avant (rich seed) | Apres |
|---|---|---|
| Nora | (catalogue base via `buildSeedMemberServices`) | cut + color + beard (geante polyvalente) |
| Mila | les 8 services Nova | cut + color (specialiste femme/couleur) |
| Leo | les 8 services Nova | beard (specialiste homme/barbe) |
| Hugo / Yasmine | les 8 services Nova | seulement les 5 extras (Olaplex, Permanente, Gloss, Coupe enfant, Chignon) |

Plus realiste (un coiffeur a sa spe) et compatible avec les fixtures historiques des tests.

### Cote tests

- `booking.integration.test.ts` : "ne renvoie aucun creneau pour un service non propose" → restoration de l'intent intra-org (`mila + beard` au lieu de `mila + service Refuge`)
- `public-organization.integration.test.ts` : "refuse un recapitulatif incoherent" sub-assert → restoration de l'intent intra-org (`cut + leo + slot-leo-2` au lieu de `service Refuge + leo + slot-leo-2`)

## Validation

- `pnpm test:integration` : 60/60 verts
- `pnpm test` : 58/58 verts
- `pnpm typecheck` : OK
- Pre-commit + pre-push : tous verts

## Impact metier

Aucun : l'apparence de la page publique `/atelier-nova` reste similaire (les 5 nouvelles prestations sont toujours proposees, juste par Hugo/Yasmine au lieu de tout le monde). Les bookings generes par `seedRichContent` continuent de fonctionner (`pick(member.serviceIds)` reste valide pour chaque catalogue specialise).